### PR TITLE
BLD: Set disk space during cf-push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
             sudo dpkg -i cf-cli_amd64.deb
             cf -v
             cf login -a https://api.fr.cloud.gov -u $CF_SERVICE_ACCOUNT -p $CF_SERVICE_PW -o gsa-ogp-srt -s $TARGET_BRANCH
-            cf push srt-fbo-scraper-$TARGET_BRANCH --docker-image $DOCKER_USER/srt-fbo-scraper-$TARGET_BRANCH
+            cf push srt-fbo-scraper-$TARGET_BRANCH --docker-image $DOCKER_USER/srt-fbo-scraper-$TARGET_BRANCH -k 4G
 
 workflows:
   version: 2


### PR DESCRIPTION
Setting disk space in cloudfoundry to 4G with `cf push` in order to be safe when downloading docs.