### PR TITLE
FIX: Handle FedConnect notices without docs and incorrectly saved pdfs

### DIFF
--- a/tests/get_fbo_attachments_test.py
+++ b/tests/get_fbo_attachments_test.py
@@ -53,6 +53,15 @@ class FboAttachmentsTestCase(unittest.TestCase):
         self.temp_outfile_path_docx = temp_outfile_path_docx
         self.temp_outfile_path_doc = temp_outfile_path_doc
 
+        fake_docx = FPDF()
+        fake_docx.add_page()
+        fake_docx.set_xy(0, 0)
+        fake_docx.set_font('arial', 'B', 13.0)
+        fake_docx.cell(ln=0, h=5.0, align='L', w=0, txt="This is a test", border=0)
+        temp_outfile_path_fake_docx = os.path.join(root_path, 'fake_docx.docx')
+        fake_docx.output(temp_outfile_path_fake_docx, 'F')
+        self.temp_outfile_path_fake_docx = temp_outfile_path_fake_docx
+
 
     def tearDown(self):
         self.fboa = None
@@ -65,6 +74,8 @@ class FboAttachmentsTestCase(unittest.TestCase):
             os.remove(self.temp_outfile_path_pdf)
         if os.path.exists(self.temp_outfile_path_docx):
             os.remove(self.temp_outfile_path_docx)
+        if os.path.exists(self.temp_outfile_path_fake_docx):
+            os.remove(self.temp_outfile_path_fake_docx)
 
 
     @requests_mock.Mocker()
@@ -303,6 +314,12 @@ class FboAttachmentsTestCase(unittest.TestCase):
 
     def test_get_attachment_text_doc(self):
         result = self.fboa.get_attachment_text(self.temp_outfile_path_doc, 'url')
+        expected = "This is a test"
+        self.assertEqual(result, expected)
+
+    def test_get_attachment_text_fake_docx(self):
+        # see GH183
+        result = self.fboa.get_attachment_text(self.temp_outfile_path_fake_docx, 'url')
         expected = "This is a test"
         self.assertEqual(result, expected)
 

--- a/utils/get_fbo_attachments.py
+++ b/utils/get_fbo_attachments.py
@@ -451,6 +451,9 @@ class FboAttachments():
         soup = BeautifulSoup(r.content, 'html.parser')
         try:
             attachments_div = soup.find('div',{'id':'div_attachments'})
+            if not attachments_div:
+                # No attachments to find here
+                return
             attachment_tables = attachments_div.find_all('table')
             attachment_rows = []
             for table in attachment_tables:
@@ -542,6 +545,9 @@ class FboAttachments():
                         file_list_fc = FboAttachments.write_fedconnect_docs(attachment_url, 
                                                                             out_path, 
                                                                             textract_extensions)
+                        if not file_list_fc:
+                            # No FedConnect documents found so continue
+                            continue
                         file_list.extend(file_list_fc)
                     #some are ftp and we can get the file now
                     elif 'ftp://' in attachment_url:

--- a/utils/get_fbo_attachments.py
+++ b/utils/get_fbo_attachments.py
@@ -98,6 +98,17 @@ class FboAttachments():
             b_text = None
             logger.error(f"Couldn't textract {file_name} from {url} since the file couldn't be found:  \
                            {e}", exc_info=True)
+        #This can be raised when a pdf is incorrectly saved as a .docx (GH183)
+        except BadZipfile as e:
+            if file_name.endswith('.docx'):
+                b_text = textract.process(file_name, 
+                                          encoding='utf-8', 
+                                          method='pdftotext', 
+                                          errors = 'ignore')
+            else:
+                b_text = None
+                logger.error(f"Exception occurred textracting {file_name} from {url}:  \
+                             {e}", exc_info=True)
         except TypeError:
             b_text = None
         except Exception as e:

--- a/utils/get_fbo_attachments.py
+++ b/utils/get_fbo_attachments.py
@@ -101,10 +101,12 @@ class FboAttachments():
         #This can be raised when a pdf is incorrectly saved as a .docx (GH183)
         except BadZipfile as e:
             if file_name.endswith('.docx'):
-                b_text = textract.process(file_name, 
+                new_name = file_name.replace('.docx','.pdf')
+                os.rename(file_name, new_name)
+                b_text = textract.process(new_name, 
                                           encoding='utf-8', 
                                           method='pdftotext', 
-                                          errors = 'ignore')
+                                          errors='ignore')
             else:
                 b_text = None
                 logger.error(f"Exception occurred textracting {file_name} from {url}:  \


### PR DESCRIPTION
This PR addresses  #182 and #183