### PR TITLE
ENH: Add db cascade

### DIFF
--- a/utils/db/db.py
+++ b/utils/db/db.py
@@ -37,9 +37,9 @@ class Notice(Base):
     feedback = Column(JSONB)
     history = Column(JSONB)
     action = Column(JSONB)
-    createdAt = Column(DateTime, nullable = False, default=datetime.datetime.utcnow)
+    createdAt = Column(DateTime, nullable = False, default = datetime.datetime.utcnow)
     updatedAt = Column(DateTime, nullable = True)
-    attachments = relationship("Attachment", back_populates="notice")
+    attachments = relationship("Attachment", back_populates = "notice", cascade = "all, delete-orphan")
 
 class NoticeType(Base):
     __tablename__ = 'notice_type'


### PR DESCRIPTION
Add the `delete-orphan` cascade behavior to notice attachments, such that a child "attachment" object will be marked for deletion when it is de-associated from the parent, not just when the parent is marked for deletion. This is a common feature when dealing with a related object that is “owned” by its parent, with a NOT NULL foreign key, so that removal of the item from the parent collection results in its deletion.