### PR TITLE
FIX: Migration fix

### DIFF
--- a/alembic/versions/3725519a3b83_add_filename_column_to_attachment.py
+++ b/alembic/versions/3725519a3b83_add_filename_column_to_attachment.py
@@ -7,7 +7,11 @@ Create Date: 2019-04-08 19:37:28.880047
 """
 from alembic import op
 import sqlalchemy as sa
+import imp
+import os
 
+alembic_helpers = imp.load_source('alembic_helpers', (
+    os.getcwd() + '/' + op.get_context().script.dir + '/alembic_helpers.py'))
 
 # revision identifiers, used by Alembic.
 revision = '3725519a3b83'
@@ -17,8 +21,10 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('attachment', sa.Column('filename', sa.Text, nullable = True))
+    if not alembic_helpers.table_has_column('attachment', 'filename'):
+        op.add_column('attachment', sa.Column('filename', sa.Text, nullable = True))
 
 
 def downgrade():
-    op.drop_column('attachment', 'filename')
+    if alembic_helpers.table_has_column('attachment', 'filename'):
+        op.drop_column('attachment', 'filename')

--- a/utils/db/db.py
+++ b/utils/db/db.py
@@ -61,6 +61,7 @@ class Attachment(Base):
     trained = Column(Boolean, nullable = True)
     createdAt = Column(DateTime, nullable = False, default=datetime.datetime.utcnow)
     updatedAt = Column(DateTime, nullable = True)
+    na_flag = Column(Boolean, default = False)
     notice = relationship("Notice", back_populates = "attachments")
 
 class Model(Base):


### PR DESCRIPTION
the prod space never received the first alembic migration, so its revision history is unaware of that migration and attempts to create a column that already exists. Solution is to make the revision conditional on the presence of the column. We also update the ORM to include the new na_flag column we're adding.