### PR TITLE
A Notebook Exploring the Feature Set and Prediction Confidence

### DIFF
--- a/eda/confidence_experiments.ipynb
+++ b/eda/confidence_experiments.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "By listing the estimator steps, we get the the details of the classifier pipeline with the best chosen hyperparameters. The estimator is a pipeline of:\n",
     "\n",
-    " 1. a TF-DIF vectorizor (with L2 norm), \n",
+    " 1. a TF-IDF vectorizor (with L2 norm), \n",
     " 2. a KBest selector (top 2000), and \n",
     " 3. a stochastic gradient descent (SGD) classifier\n",
     "\n",

--- a/eda/confidence_experiments.ipynb
+++ b/eda/confidence_experiments.ipynb
@@ -1,0 +1,833 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn import metrics\n",
+    "from sklearn.feature_selection import SelectKBest, chi2\n",
+    "from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "from sklearn.linear_model import SGDClassifier\n",
+    "from imblearn.pipeline import Pipeline\n",
+    "import dill as pickle\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Allow import from parent directory (for utils for example)\n",
+    "sys.path.append(os.path.abspath(os.path.join('..')))\n",
+    "import utils.train as train"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Import the Estimator and Take a Look"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator = pickle.load(open('../utils/binaries/estimator.pkl','rb'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By listing the estimator steps, we get the the details of the classifier pipeline with the best chosen hyperparameters. The estimator is a pipeline of:\n",
+    "\n",
+    " 1. a TF-DIF vectorizor (with L2 norm), \n",
+    " 2. a KBest selector (top 2000), and \n",
+    " 3. a stochastic gradient descent (SGD) classifier\n",
+    "\n",
+    "Because the SGD classifier uses a \"modified_huber\" loss function, it not only gives us predictions, but probabilities of fit. This could be useful to determine the confidence of the predictions (identifying a \"yellow\" zone) that could be communicated to users for details and reclassification."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('vectorizer',\n",
+       "  TfidfVectorizer(analyzer='word', binary=False, decode_error='strict',\n",
+       "                  dtype=<class 'numpy.int64'>, encoding='utf-8', input='content',\n",
+       "                  lowercase=True, max_df=1.012474489021681, max_features=None,\n",
+       "                  min_df=2, ngram_range=(1, 2), norm='l2', preprocessor=None,\n",
+       "                  smooth_idf=True, stop_words='english', strip_accents=None,\n",
+       "                  sublinear_tf=True, token_pattern='(?u)\\\\b\\\\w\\\\w+\\\\b',\n",
+       "                  tokenizer=None, use_idf=True, vocabulary=None)),\n",
+       " ('select', SelectKBest(k=2000, score_func=<function chi2 at 0x7f42f6fb4730>)),\n",
+       " ('clf',\n",
+       "  SGDClassifier(alpha=array([0.00156602]), average=False, class_weight='balanced',\n",
+       "                early_stopping=None, epsilon=0.1, eta0=0.0, fit_intercept=True,\n",
+       "                l1_ratio=0.15, learning_rate='optimal', loss='modified_huber',\n",
+       "                max_iter=None, n_iter_no_change=None, n_jobs=1,\n",
+       "                penalty='elasticnet', power_t=0.5, random_state=None,\n",
+       "                shuffle=True, tol=None, validation_fraction=None, verbose=0,\n",
+       "                warm_start=False))]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "estimator.steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a quick sanity check, let's run the estimator on a couple of examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 1])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "estimator.predict(['This is a bunch of words that do not mention what we want to capture',\n",
+    "                   'This is another bunch of words but we care about Section 508 accessibility.'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "OK, that makes sense, but what about the cofidence of it being \"Green\" (1)?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.27327843, 0.62025061])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "estimator.predict_proba(['This is a bunch of words that do not mention what we want to capture',\n",
+    "                         'This is another bunch of words but we care about Section 508 accessibility.'])[:,1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So we're pretty sure that the first line is not GREEN, while the second one is \"kind of\" GREEN."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Out of curiosity, what are the words (features) that have the most significance choosing between GREEN and RED? We can figure this out by pulling out the features and scores from the estimator steps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>features</th>\n",
+       "      <th>coef</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1577</td>\n",
+       "      <td>section 508</td>\n",
+       "      <td>2.143648</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>508</td>\n",
+       "      <td>2.119495</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>830</td>\n",
+       "      <td>function perform</td>\n",
+       "      <td>1.883782</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1304</td>\n",
+       "      <td>perform criteria</td>\n",
+       "      <td>1.749019</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1760</td>\n",
+       "      <td>task order</td>\n",
+       "      <td>1.524084</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1974</td>\n",
+       "      <td>wall</td>\n",
+       "      <td>-0.411968</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>90</td>\n",
+       "      <td>afb</td>\n",
+       "      <td>-0.519698</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>274</td>\n",
+       "      <td>cabl</td>\n",
+       "      <td>-0.817065</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>99</td>\n",
+       "      <td>air</td>\n",
+       "      <td>-0.976992</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>100</td>\n",
+       "      <td>air forc</td>\n",
+       "      <td>-1.260464</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>2000 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              features      coef\n",
+       "1577       section 508  2.143648\n",
+       "1                  508  2.119495\n",
+       "830   function perform  1.883782\n",
+       "1304  perform criteria  1.749019\n",
+       "1760        task order  1.524084\n",
+       "...                ...       ...\n",
+       "1974              wall -0.411968\n",
+       "90                 afb -0.519698\n",
+       "274               cabl -0.817065\n",
+       "99                 air -0.976992\n",
+       "100           air forc -1.260464\n",
+       "\n",
+       "[2000 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "features = estimator.named_steps['vectorizer'].get_feature_names()\n",
+    "mask = estimator.named_steps['select'].get_support()\n",
+    "new_features = [ feature for bool, feature in zip (mask, features) if bool ]\n",
+    "nf = pd.DataFrame({'features': new_features, 'coef': estimator.named_steps['clf'].coef_[0] })\n",
+    "nf.sort_values(['coef'], ascending=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pull in the Labeled Data\n",
+    "\n",
+    "Let's pull in the labeled data from the pkl file. It looks like the estimator was trained off of the result of 80% of the labeled data (which is a great best practice because you can then double check your work on a 20% test set that was set aside)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "993"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "attachments = pickle.load(open('../utils/binaries/train.pkl','rb'))\n",
+    "len(attachments)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(993, 993)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The following removes numbers (except 508) small and large words, stop words\n",
+    "# and then uses the nltk porter stemmer on the text\n",
+    "x,y = train.prepare_samples(attachments)\n",
+    "len(x), len(y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(794, 794, 199, 199)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now let's pull out the training and test sets the same way that\n",
+    "# the training code appears to pull it out.\n",
+    "x_train, x_test, y_train, y_test = train.train_test_split(x, y, stratify=y,\n",
+    "                                                          test_size=0.2, random_state=123)\n",
+    "len(x_train), len(y_train), len(x_test), len(y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Retrain the Model So We Have a Clean Test Set\n",
+    "I ran the experiments below and discovered that the probability distributions and classification reports for the test and training sets were almost identical. So I have to conclude that I don't have a \"clean\" test set (that I have some overlap between the test set and the training set used to create the estimator). So to make the test set clean, let me re-train the estimator on the training set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('vectorizer',\n",
+       "  TfidfVectorizer(analyzer='word', binary=False, decode_error='strict',\n",
+       "                  dtype=<class 'numpy.float64'>, encoding='utf-8',\n",
+       "                  input='content', lowercase=True, max_df=1.012474489021681,\n",
+       "                  max_features=None, min_df=2, ngram_range=(1, 2), norm='l2',\n",
+       "                  preprocessor=None, smooth_idf=True, stop_words='english',\n",
+       "                  strip_accents=None, sublinear_tf=True,\n",
+       "                  token_pattern='(?u)\\\\b\\\\w\\\\w+\\\\b', tokenizer=None, use_idf=True,\n",
+       "                  vocabulary=None)),\n",
+       " ('select', SelectKBest(k=2000, score_func=<function chi2 at 0x7f42f6fb4730>)),\n",
+       " ('clf',\n",
+       "  SGDClassifier(alpha=0.00156602, average=False, class_weight='balanced',\n",
+       "                early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,\n",
+       "                l1_ratio=0.15, learning_rate='optimal', loss='modified_huber',\n",
+       "                max_iter=1000, n_iter_no_change=5, n_jobs=None, penalty='l2',\n",
+       "                power_t=0.5, random_state=None, shuffle=True, tol=0.001,\n",
+       "                validation_fraction=0.1, verbose=0, warm_start=False))]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "estimator = Pipeline([('vectorizer', \n",
+    "                       TfidfVectorizer(stop_words='english', ngram_range=(1, 2),\n",
+    "                                       min_df=2, max_df=1.012474489021681, \n",
+    "                                       norm='l2', sublinear_tf=True)),\n",
+    "                     ('select', SelectKBest(chi2, k=2000)),\n",
+    "                     ('clf', SGDClassifier(class_weight = 'balanced', \n",
+    "                                           alpha=0.00156602,\n",
+    "                                           loss='modified_huber'))])\n",
+    "estimator.steps\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator.fit(x_train, y_train);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Re-run our earlier examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 1])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "estimator.predict(['This is a bunch of words that do not mention what we want to capture',\n",
+    "                   'This is another bunch of words but we care about Section 508 accessibility.'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.26928693, 0.57457576])"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "estimator.predict_proba(['This is a bunch of words that do not mention what we want to capture',\n",
+    "                         'This is another bunch of words but we care about Section 508 accessibility.'])[:,1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because I re-trained, did my selected K features change?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>features</th>\n",
+       "      <th>coef</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>1581</td>\n",
+       "      <td>section 508</td>\n",
+       "      <td>1.895117</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>508</td>\n",
+       "      <td>1.855665</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>824</td>\n",
+       "      <td>function perform</td>\n",
+       "      <td>1.571530</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1303</td>\n",
+       "      <td>perform criteria</td>\n",
+       "      <td>1.477681</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1768</td>\n",
+       "      <td>task order</td>\n",
+       "      <td>1.466099</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1983</td>\n",
+       "      <td>wall</td>\n",
+       "      <td>-0.389116</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>90</td>\n",
+       "      <td>afb</td>\n",
+       "      <td>-0.540785</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>276</td>\n",
+       "      <td>cabl</td>\n",
+       "      <td>-0.701897</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>99</td>\n",
+       "      <td>air</td>\n",
+       "      <td>-0.919970</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>100</td>\n",
+       "      <td>air forc</td>\n",
+       "      <td>-1.111299</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>2000 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              features      coef\n",
+       "1581       section 508  1.895117\n",
+       "1                  508  1.855665\n",
+       "824   function perform  1.571530\n",
+       "1303  perform criteria  1.477681\n",
+       "1768        task order  1.466099\n",
+       "...                ...       ...\n",
+       "1983              wall -0.389116\n",
+       "90                 afb -0.540785\n",
+       "276               cabl -0.701897\n",
+       "99                 air -0.919970\n",
+       "100           air forc -1.111299\n",
+       "\n",
+       "[2000 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "features = estimator.named_steps['vectorizer'].get_feature_names()\n",
+    "mask = estimator.named_steps['select'].get_support()\n",
+    "new_features = [ feature for bool, feature in zip (mask, features) if bool ]\n",
+    "nf = pd.DataFrame({'features': new_features, 'coef': estimator.named_steps['clf'].coef_[0] })\n",
+    "nf.sort_values(['coef'], ascending=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Slightly different coefficients, so it looks like I have slightly different training data or paramters. But overall they didn't change too much. So I should be able to use this to look at the confidence of the predictions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# So, How Confident are the Predictions?\n",
+    "Let's create a histogram of the probability of predicting GREEN (1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_prob = estimator.predict_proba(x_test)[:,1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([10.,  1.,  0.,  0.,  6., 32., 36., 29., 22., 13., 13.,  3.,  6.,\n",
+       "        2.,  3.,  0.,  5.,  3.,  2., 13.])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAEWCAYAAABhffzLAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAdVUlEQVR4nO3de5wcVZ338c+XEJZbECGIQySMERQRJcSBxYd1RS67CChBJYggQVkiusoq6BoRVxRZwF1l10ddjAuGq9yRIPAoIIK4mpjIIIFwE0MgCYQ7BMIl4ff8UWeybWcmUzM91T095/t+vfo1dT+/6q751elT1acUEZiZWT7WaXUAZmbWXE78ZmaZceI3M8uME7+ZWWac+M3MMuPEb2aWGSf+DEk6SdL5g1z3SEm3rmX+dZKm9raspOWSJgym3MGQdKakrw7Rtsan+Eel8V9J+oeh2Hba3ur3rZkkfVPS45IeaXbZ1jpO/G1C0kJJK1LyeVTSTEkbtzquehHxvog4p495G0fEAwAp/m8Otpya9+M5SU9L+h9Jx0hafUxHxDERcXLJbe29tmUiYlGKf9VgY64pb40T79ret6pIGg8cD+wQEa+vm3dYOtaWp/f51Zrx5Q2Uub2klf0ss7mkc9Nx/qykeyQdV3L7F0k6cbDx5cKJv728PyI2BiYBXcAaB7gKuXyu74+IMcA2wGnAl4CzhroQSesO9TaHifHAExGxrH5GRFyQTnQbA+8DlvSMp2lV+h4g4M3ApsBBwJ8rLjMruSSIESUiFgPXATvC6maHUyT9BngBmCBpK0mzJD0p6X5JR9dtZn1JF6ca8x8k7dQzQ9J0SX9K8+6SdFDdupL0PUnPSLpb0l41M/psApEUkraVNA04DPjnVIO8WtIXJV1et/x3Jf1niffjmYiYBRwCTJXU876s/lYhaaykn6VvB09K+rWkdSSdR5EAr06x/LOkzhTrUZIWAb+smVZ7EniTpDmpVnqVpM1SWXtIerhuXxZK2lvSvsAJwCGpvNvr37cU14mSHpS0LNV+X5Pm9cQxVdKi1Ezzlb7eG0mvSes/lrZ3Ytr+3sD1wFYpjpn9vc+9bHvrtN+PS3pA0jE183aXdFt6bx6RdGqadQswqubbw869bHoX4IL0ub4aEXdFxJU1295R0i8lPSVpgaTJafqxwIeAr6ZtXzrQfcpGRPjVBi9gIbB3Gt4auBM4OY3/ClgEvA1YFxhN8Q/2A2B9YCLwGLBnWv4k4BXgw2nZL1DUqEan+QcDW1FUDA4Bngc60rwjgZXA59O6hwDPAJvVxPIPNcveWrMPAWybhmcC36yZ15HK2TSNrwssA97Z3/tRN30R8Kn6MoBTgTNTzKOBdwPqbVtAZ4r1XGAjYIOaaevW7OdiipPvRsDlwPlp3h7Aw2v5/E7qWbZmfu379gngfmACsDFwBXBeXWw/SnHtBLwEvLWP9+lc4CpgTFr3XuCovuLsYxu97c8o4A6Kb1nrUdTOFwHvSfNvAw5Ow2OAv07D2wMr+ynvfOB2YGrP8VIzbxNgKUXFYRTFSeJJ/ve4ugg4sdX/r8P95Rp/e/mppKeBW4GbgX+tmTczIu6MiJXA64HdgS9FxIsR0Q38N3BEzfLzIuKyiHgF+A7FCWI3gIi4NCKWRFHbuhi4D9i1Zt1lwH9ExCtp/j3A/o3sWEQspThZHZwm7Qs8HhHzBripJcBmvUx/heLksk2K+9eRMsVanBQRz0fEij7mnxcR8yPieeCrwBSli78NOgz4TkQ8EBHLgS8DH6n7tvH1iFgREbdTJMmd6jeSYvkI8OWIeC4iFgLfBj42BDH+DbB+RJweES9HxL3Aj1N5ULzfb5a0eSp79gC2/UmKE+nngbtTG3/PNZiDgPlRNEWtiojfA1dT1PStJCf+9jI5IjaNiG0i4tN1CemhmuGtgCcj4rmaaQ8C43pbPiJeBR5O6yHpCEndqVnkaYpa7diadRfXJc0He9Zt0DnA4Wn4cOC8QWxjHEUNsN6/UdSif5GaJaaX2NZDA5j/IMU3ibF9LDsQW6Xt1W57XWDLmmm1d+G8QPHNoN7YFFP9tsb1suxAbQN09hwj6Tg5jqLSAUVt/R3AvZJmS/r7shtOJ9tvRMREYHOKxH65pJ7rOX9bV+6HKE7qVpIT/8hRm4iXAJulf5Qe4ymaJnps3TOg4mLwG4AlkrahaEb4DLB5RGwKzKe42NZjnKTa8fGpzMHG2+OnwDtSG/0BwAUD2aCkXSiS2hq3m6Za5/ERMQH4AHBczbWJvmr+/X0j2LpmeDxFLfdxiiarDWviGgVsMYDtLqFIcLXbXgk82s969R5PMdVva3Hviw/IQ8DdqSLS8xoTEQcBRMSCiDgEeB3wXeAKSevR/77/hYh4huLC/SYp9oeAX9SVu3FEfK5nlSHYtxHPiX8EioiHgP8BTpW0vqR3AEdRtJ32eKekD6bmg89RtBP/jqK9OiiuCSDp46SLyDVeBxwrabSkg4G3AtcOMMxHKdqwa+N+EbgMuBCYExGLymxI0iaSDqBo3z0/Iu7oZZkD0oVlUVyTWAW82lcsJR0uaQdJGwLfAC6L4nbPeykunu8vaTTF3Vd/VbPeoxS15b7+/34CfF7SG1XcsvuvwMWpGa+0FMslwCmSxqST+nH85XEwWLcCSPpcOsbWlfQOSZPS9CNSM88qivc70msZxcXd8X1tWMXtrpPS8bUBcCzFSex+isrBzpIOSfPXk7SbpDen1Qf7WWbFiX/kOpTiYt4S4ErgaxFxQ838qyguzD5F0eb7wdT2fRdFO/BvKf6J3g78pm7bs4HtKP4ZTwE+HBFPDDC+s4Ad0tf1n9ZMPyeVWaaZ52pJz1HUAr9Cca3i430sux1wA7CcYt9+EBE3pXmnAiemWL4wgH04j+IC8iMU10iOhdW11E9TXFdZTPENoPYun567TZ6Q9Idetnt22vYtFBfdXwQ+O4C4an02lf8ARbK+MG2/Iena0H7A/6FoPnoM+C/+t8npAOCe9PmcCkxJx9dTwLeAeen9ntjL5tehODk9SfG+7Q7sFxEvpfX/nuJzXkpxfH+TokkLYAawS9r2RY3u50jVc1eD2bCQaoJ3A6+PiGdbHY/ZSOQavw0bqenjOOAiJ32z6ozUXyRam5G0EUXT0oMUt3KaWUXc1GNmlhk39ZiZZaYtmnrGjh0bnZ2drQ7DzKytzJs37/GI2KJ+elsk/s7OTubOndvqMMzM2oqkB3ub7qYeM7PMOPGbmWXGid/MLDNO/GZmmXHiNzPLjBO/mVlmnPjNzDLjxG9mlhknfjOzzLTFL3etPXROv6ah9Ree1tDz2s2sJNf4zcwyU1niT8/hnCPpdkl3Svp6mj5T0p8ldadXb49eMzOzilTZ1PMSsGdELE8PnL5V0nVp3hcj4rIKyzYzsz5UlvijeMLL8jQ6Or381Bczsxar9OKupFHAPGBb4PsRMVvSp4BTJP0LcCMwPSJe6mXdacA0gI6ODrq7u6sM1YbAlAmrGlrfn7FZczTl0YuSNgWuBD4LPAE8AqwHzAD+FBHfWNv6XV1d4f74hz/f1WM2vEiaFxFd9dObcldPRDwN3ATsGxFLo/AS8GNg12bEYGZmhSrv6tki1fSRtAGwD3C3pI40TcBkYH5VMZiZ2ZqqbOPvAM5J7fzrAJdExM8k/VLSFoCAbuCYCmMwM7M6Vd7V80dg516m71lVmWZm1j//ctfMLDNO/GZmmXHiNzPLjBO/mVlmnPjNzDLjxG9mlhknfjOzzDjxm5llxonfzCwzTvxmZplx4jczy4wTv5lZZip9Ape1n0YfpmJmw59r/GZmmXHiNzPLjBO/mVlmnPjNzDLjxG9mlhknfjOzzDjxm5llprLEL2l9SXMk3S7pTklfT9PfKGm2pPslXSxpvapiMDOzNVVZ438J2DMidgImAvtK2g04HTgjIrYFngKOqjAGMzOrU1nij8LyNDo6vQLYE7gsTT8HmFxVDGZmtqZKu2yQNAqYB2wLfB/4E/B0RKxMizwMjOtj3WnANICOjg66u7urDNWSKRNWtaxsf8ZmzVFp4o+IVcBESZsCVwLbD2DdGcAMgK6urpg4cWI1QdpfmHzR4paV/a1p/ozNmqEpd/VExNPATcC7gE0l9Zxw3gC0LtOYmWWoyrt6tkg1fSRtAOwDLKA4AXw4LTYVuKqqGMzMbE1VNvV0AOekdv51gEsi4meS7gIukvRN4DbgrApjMDOzOpUl/oj4I7BzL9MfAHatqlwzM1s7P4jFho1GHgKz8LT9hzASs5HNXTaYmWXGid/MLDNO/GZmmXHiNzPLjBO/mVlmnPjNzDLjxG9mlhknfjOzzDjxm5llxonfzCwzTvxmZplx4jczy4wTv5lZZpz4zcwy48RvZpYZJ34zs8w48ZuZZcaJ38wsM078ZmaZqSzxS9pa0k2S7pJ0p6R/StNPkrRYUnd67VdVDGZmtqYqH7a+Ejg+Iv4gaQwwT9L1ad4ZEfHvFZZtZmZ9qCzxR8RSYGkafk7SAmBcVeWZmVk5Vdb4V5PUCewMzAZ2Bz4j6QhgLsW3gqd6WWcaMA2go6OD7u7uZoSavSkTVrU6hEHx8WFWniKi2gKkjYGbgVMi4gpJWwKPAwGcDHRExCfWto2urq6YO3dupXFaoXP6Na0OYVAWnrZ/q0MwG3YkzYuIrvrpld7VI2k0cDlwQURcARARj0bEqoh4FfgRsGuVMZiZ2V+q8q4eAWcBCyLiOzXTO2oWOwiYX1UMZma2pirb+HcHPgbcIamnAfYE4FBJEymaehYCn6wwBjMzq1PlXT23Aupl1rVVlWlmZv3zL3fNzDLjxG9mlhknfjOzzDjxm5llxonfzCwzpRK/pLdXHYiZmTVH2Rr/DyTNkfRpSa+pNCIzM6tUqcQfEe8GDgO2puhe+UJJ+1QamZmZVaJ0G39E3AecCHwJeA/wXUl3S/pgVcGZmdnQK9vG/w5JZwALgD2B90fEW9PwGRXGZ2ZmQ6xslw3/F/hv4ISIWNEzMSKWSDqxksjMzKwSZRP//sCKiFgFIGkdYP2IeCEizqssOrOSGnmOgPvyt9yUbeO/AdigZnzDNM3MzNpM2cS/fkQs7xlJwxtWE5KZmVWpbOJ/XtKknhFJ7wRWrGV5MzMbpsq28X8OuFTSEoo+9l8PHFJZVGZmVplSiT8ifi9pe+AtadI9EfFKdWGZmVlVBvIErl2AzrTOJElExLmVRGVmZpUplfglnQe8CegGVqXJATjxm5m1mbI1/i5gh4iIKoMxM7Pqlb2rZz7FBd3SJG0t6SZJd0m6U9I/pembSbpe0n3p72sHGrSZmQ1e2cQ/FrhL0s8lzep59bPOSuD4iNgB2A34R0k7ANOBGyNiO+DGNG5mZk1StqnnpIFuOCKWAkvT8HOSFgDjgAOBPdJi5wC/oujx08zMmqDs7Zw3S9oG2C4ibpC0ITCqbCGSOoGdgdnAlumkAPAIsGUf60wDpgF0dHTQ3d1dtjhrwJQJq/pfaITxsWW5KXtXz9EUSXgzirt7xgFnAnuVWHdj4HLgcxHxrKTV8yIiJPV6wTgiZgAzALq6umLixIllQrUGTb5ocatDaLpvTfOxZXkp28b/j8DuwLOw+qEsr+tvJUmjKZL+BRFxRZr8qKSONL8DWDbQoM3MbPDKJv6XIuLlnhFJ61Lcx98nFVX7s4AFEfGdmlmzgKlpeCpwVflwzcysUWUT/82STgA2SM/avRS4up91dgc+BuwpqTu99gNOA/aRdB+wdxo3M7MmKXtXz3TgKOAO4JPAtRRP5OpTRNxK0aFbb/q9NmBmZtUoe1fPq8CP0svMzNpY2bt6/kwvbfoRMWHIIzIzs0oNpK+eHusDB1Pc2mlmZm2m1MXdiHii5rU4Iv6D4gHsZmbWZso29UyqGV2H4hvAQPryNzOzYaJs8v52zfBKYCEwZcijMTOzypW9q+e9VQdiZmbNUbap57i1za/7Za6ZmQ1jA7mrZxeK7hYA3g/MAe6rIigzM6tO2cT/BmBSRDwHIOkk4JqIOLyqwMzMrBpl++rZEni5Zvxl+uhH38zMhreyNf5zgTmSrkzjkymenmVmZm2m7F09p0i6Dnh3mvTxiLiturDMzKwqZZt6ADYEno2I/wQelvTGimIyM7MKlUr8kr5G8UD0L6dJo4HzqwrKzMyqU7bGfxDwAeB5gIhYAoypKigzM6tO2cT/ckQEqWtmSRtVF5KZmVWpbOK/RNIPgU0lHQ3cgB/KYmbWlsre1fPv6Vm7zwJvAf4lIq6vNDIzM6tEv4lf0ijghtRRW+lkL+ls4ABgWUTsmKadBBwNPJYWOyEirh1o0GZmNnj9NvVExCrgVUmvGeC2ZwL79jL9jIiYmF5O+mZmTVb2l7vLgTskXU+6swcgIo7ta4WIuEVSZ0PRmZnZkCub+K9Ir6HwGUlHAHOB4yPiqSHarpmZlbDWxC9pfEQsioih6pfnv4CTKW4LPZniyV6f6KPsacA0gI6ODrq7u4coBFubKRNWtTqEpvOxZblRcXt+HzOlP0TEpDR8eUR8aEAbL5p6ftZzcbfsvHpdXV0xd+7cgRRtg9Q5/ZpWh9B0C0/bv9UhmFVC0ryI6Kqf3t/FXdUMTxiCIDpqRg8C5je6TTMzG5j+2vijj+F+SfoJsAcwVtLDwNeAPSRNTNtaCHxyINs0M7PG9Zf4d5L0LEXNf4M0TBqPiNikrxUj4tBeJp81uDDNzGyorDXxR8SoZgViZmbNMZD++M3MbARw4jczy4wTv5lZZpz4zcwy48RvZpaZsn31mI1Yrfy1sn81PPI1enxVcYy4xm9mlhknfjOzzDjxm5llxonfzCwzTvxmZplx4jczy4wTv5lZZpz4zcwy48RvZpYZJ34zs8w48ZuZZcaJ38wsM078ZmaZqSzxSzpb0jJJ82umbSbpekn3pb+vrap8MzPrXZU1/pnAvnXTpgM3RsR2wI1p3MzMmqiyxB8RtwBP1k0+EDgnDZ8DTK6qfDMz612zH8SyZUQsTcOPAFv2taCkacA0gI6ODrq7uwdV4IVzFg1qPYCP7jp+0Ou2qykTVrU6hKwM9ri29tHo/1QVx0jLnsAVESEp1jJ/BjADoKurKyZOnDiociZftHhwAQLfmja4MttZI++XDVyOx1huGv2fquIYafZdPY9K6gBIf5c1uXwzs+w1O/HPAqam4anAVU0u38wse1XezvkT4LfAWyQ9LOko4DRgH0n3AXuncTMza6LK2vgj4tA+Zu1VVZlmZtY//3LXzCwzTvxmZplx4jczy4wTv5lZZpz4zcwy48RvZpYZJ34zs8w48ZuZZcaJ38wsM078ZmaZceI3M8uME7+ZWWac+M3MMuPEb2aWGSd+M7PMOPGbmWXGid/MLDOVPYHLWqdz+jWtDsGaoJHPeeFp+w9hJNZuXOM3M8uME7+ZWWZa0tQjaSHwHLAKWBkRXa2Iw8wsR61s439vRDzewvLNzLLkph4zs8y0qsYfwC8kBfDDiJhRv4CkacA0gI6ODrq7uwdV0JQJqwYd5GDLbLVG9tmaq5FjLMdj+8I5iwa97kd3HT+EkZTX6P9jFZ+VImLIN9pvodK4iFgs6XXA9cBnI+KWvpbv6uqKuXPnDqqsHG958+2c7aORY8zH9sC0ap8b/X9sJG5J83q7htqSpp6IWJz+LgOuBHZtRRxmZjlqeuKXtJGkMT3DwN8B85sdh5lZrlrRxr8lcKWknvIvjIj/14I4zMyy1PTEHxEPADs1u1wzMyv4dk4zs8w48ZuZZcaJ38wsM078ZmaZceI3M8uME7+ZWWb8BC6zFmrH7jXasdsEaN+4q+Aav5lZZpz4zcwy48RvZpYZJ34zs8z44q5ZhtrxonIrjbT3yzV+M7PMOPGbmWXGid/MLDNO/GZmmXHiNzPLjO/qWYtGr+SPtJ95m9nI4Bq/mVlmnPjNzDLTksQvaV9J90i6X9L0VsRgZparpid+SaOA7wPvA3YADpW0Q7PjMDPLVStq/LsC90fEAxHxMnARcGAL4jAzy1Ir7uoZBzxUM/4w8Nf1C0maBkxLo8sl3TPI8sYCjw9y3Ybo9FaUCrRwn1vI+9wGhuB/ou32uVE6vaF93qa3icP2ds6ImAHMaHQ7kuZGRNcQhNQ2vM958D7noYp9bkVTz2Jg65rxN6RpZmbWBK1I/L8HtpP0RknrAR8BZrUgDjOzLDW9qSciVkr6DPBzYBRwdkTcWWGRDTcXtSHvcx68z3kY8n1WRAz1Ns3MbBjzL3fNzDLjxG9mlpkRk/j76wZC0l9JujjNny2ps/lRDq0S+3ycpLsk/VHSjZJ6vae3nZTt7kPShySFpLa+9a/M/kqakj7nOyVd2OwYh1qJ43q8pJsk3ZaO7f1aEedQknS2pGWS5vcxX5K+m96TP0qa1FCBEdH2L4qLxH8CJgDrAbcDO9Qt82ngzDT8EeDiVsfdhH1+L7BhGv5UDvuclhsD3AL8DuhqddwVf8bbAbcBr03jr2t13E3Y5xnAp9LwDsDCVsc9BPv9t8AkYH4f8/cDrgME7AbMbqS8kVLjL9MNxIHAOWn4MmAvSWpijEOt332OiJsi4oU0+juK30y0s7LdfZwMnA682MzgKlBmf48Gvh8RTwFExLImxzjUyuxzAJuk4dcAS5oYXyUi4hbgybUsciBwbhR+B2wqqWOw5Y2UxN9bNxDj+lomIlYCzwCbNyW6apTZ51pHUdQY2lm/+5y+Am8dEY09RWd4KPMZvxl4s6TfSPqdpH2bFl01yuzzScDhkh4GrgU+25zQWmqg/+9rNWy7bLChI+lwoAt4T6tjqZKkdYDvAEe2OJRmWpeiuWcPim90t0h6e0Q83dKoqnUoMDMivi3pXcB5knaMiFdbHVi7GCk1/jLdQKxeRtK6FF8Rn2hKdNUo1fWFpL2BrwAfiIiXmhRbVfrb5zHAjsCvJC2kaAud1cYXeMt8xg8DsyLilYj4M3AvxYmgXZXZ56OASwAi4rfA+hSdt41kQ9rVzUhJ/GW6gZgFTE3DHwZ+GemqSZvqd58l7Qz8kCLpt3vbL/SzzxHxTESMjYjOiOikuK7xgYiY25pwG1bmuP4pRW0fSWMpmn4eaGaQQ6zMPi8C9gKQ9FaKxP9YU6NsvlnAEenunt2AZyJi6WA3NiKaeqKPbiAkfQOYGxGzgLMovhLeT3ER5SOti7hxJff534CNgUvTdexFEfGBlgXdoJL7PGKU3N+fA38n6S5gFfDFiGjbb7Il9/l44EeSPk9xoffINq/EIeknFCfwsenaxdeA0QARcSbFtYz9gPuBF4CPN1Rem79fZmY2QCOlqcfMzEpy4jczy4wTv5lZZpz4zcwy48RvZpYZJ34bsSStktQtab6kSyVtOMD1lw9w+ZmSPtzL9C5J303DR0r6Xho+RtIRNdO3Gkh5ZoPlxG8j2YqImBgROwIvA8fUzkw/hqn8fyAi5kbEsb1MPzMizk2jRwJO/NYUTvyWi18D20rqTH29nwvMB7aWdKikO9I3g9NrV5J0Rurn/kZJW6RpR0v6vaTbJV1e901ib0lzJd0r6YC0/B6SflYfkKSTJH0hfUvoAi5I31D2l/TTmuX2kXTl0L8llisnfhvxUt9M7wPuSJO2A34QEW8DXqHownlPYCKwi6TJabmNKH4t+jbgZopfUwJcERG7RMROwAKKvmN6dFJ0Lbw/cKak9fuLLyIuA+YCh0XERIpfaW7fc6Kh+JXm2QPecbM+OPHbSLaBpG6KpLqIotsOgAdTn+YAuwC/iojHUnfdF1A8FAPgVeDiNHw+8DdpeEdJv5Z0B3AY8LaaMi+JiFcj4j6KPnO2H2jQqfuB8yi6Ht4UeBft36W2DSMjoq8esz6sSDXo1VKfRc8Pcns9/ZvMBCZHxO2SjiR1kla3TF/jZf0YuJriYTKXppOS2ZBwjd9yNwd4j6SxkkZR9PV+c5q3DkVPrgAfBW5Nw2OApZJGU9T4ax0saR1Jb6J4fOA9JeN4Lm0XgIhYQvFkqRMpTgJmQ8Y1fstaRCxV8UDvmyieZ3pNRFyVZj8P7CrpRGAZcEia/lVgNkVXwLOpSdgUTUpzKB4NeExEvFjyCZ8zKa4JrADeFRErKJqdtoiIBQ3sotka3Dun2TCV7ve/LSLO6ndhswFw4jcbhiTNo/jGsc8IeHKaDTNO/GZmmfHFXTOzzDjxm5llxonfzCwzTvxmZplx4jczy8z/B4kR7726C5dHAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "bins = 20\n",
+    "n, b, patches = plt.hist(x=test_prob, bins=bins)\n",
+    "plt.grid(axis='y', alpha=0.75)\n",
+    "plt.xlabel('Probability')\n",
+    "plt.ylabel('Frequency')\n",
+    "plt.title('Probability Distribution of Test Set')\n",
+    "n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That is an interesting clump around 0.3-0.35, but there is a significant amount in the 0.4-0.6 range...\n",
+    "\n",
+    "What about the training set?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_prob = estimator.predict_proba(x_train)[:,1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 41.,   0.,   2.,   2.,  19., 163., 132., 102.,  82.,  54.,  45.,\n",
+       "        27.,  17.,  13.,  13.,  15.,   5.,   8.,  10.,  44.])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3de5wcVZn/8c8XgnKVgFEcksAQjWBAGXFgcV1dFNwNgiSrGECQwEZnUYRVVAyKC78VFHAFYVUwCiYgEAIiRJFVQC7iSiKXgXCVLIQwSSDc7wIJz++Pc6ZohplMT8909/T09/165ZWqU6eqnuqu6afPqepTigjMzMwA1qp3AGZmNnw4KZiZWcFJwczMCk4KZmZWcFIwM7OCk4KZmRWcFEYwScdK+kWF6x4k6fo1LL9c0vTe6kp6VtKESvZbCUlnSPrWEG1rixz/2nn+GkmfHYpt5+0Vr1stSTpO0qOSHqrBvqZLunyo61ptOCkMM5KWSHohfzA9LGm2pA3rHVdPEbF7RMzpY9mGEXEfQI7/uEr3U/J6PCPpSUn/K+kQScW5GxGHRMS3y9zWbmuqExFLc/yrK425ZH+vS8pret2qRdIWwFeASRHxth7L9s/n2rP5dX6lZP7ZSvYXEXMiYvehrjtQkj4k6c+SnpL0uKTrJe1QxnqjJIWk1mrENdw5KQxPH4+IDYEdgHbg6J4VlDTL+/fxiNgI2BI4Afg6cOZQ70TSqKHe5jCxBfBYRKzsuSAizs1JcENgd2B593wue41GeY0kbQLMB04GNgXGAccBL9UzrkbQLB8qDSkilgGXA9tB0ZVxvKQ/Ac8DEyRtLml+/ia0WNLnemxmXUkX5G/aN0vavnuBpJmS/i8vu1PSv/RYV5J+mL9p3S1p15IFfXar5G9Z75DUAewPHJm/ef5a0tck/bJH/dMknVrG6/FURMwH9gGmS+p+XYrWiKQxkn6TWxWPS/qjpLUknUP6cPx1juVISa051hmSlgJ/KCkr/fB7u6SFkp6WdKmkTfO+dpHU1eNYlkjaTdJk4BvAPnl/t/Z83XJcR0t6QNJKSWdL2jgv645juqSluevnm329NpI2zus/krd3dN7+bsAVwOY5jtn9vc69bLsrv2+LgOdy2dGS7svnzh2S9iqp/1lJ1+Tp7m/d/5bPzycknVZh3bUl/UDSY3nfh0nqa0iGrYFVEXFhRKyOiOcj4n8i4vYe+7477+dySePzouvy/3fk1+yTA33NGlpE+N8w+gcsAXbL0+OBO4Bv5/lrgKXAtsAoYB3SCfxjYF2gDXgE+EiufyzwMrB3rvtV4H5gnbz8U8DmpC8H+5D+4FvysoOAVcCX87r7AE8Bm5bE8tmSuteXHEMA78jTs4HjSpa15P2MzvOjgJXA+/p7PXqULwU+33MfwHeBM3LM6wAfBNTbtoDWHOvZwAbAeiVlo0qOcxkpMW8A/BL4RV62C9C1hvfv2O66JctLX7d/BRYDE4ANgYuBc3rE9tMc1/bAi8C7+nidzgYuBTbK6/4VmNFXnH1so9d6QBdwE+nb9nq5bFp+L9cCPg08C2yWl30WuKbk/Y0c28Y5tsdLXqOB1P0icDswlvTt/2og+jiWTYAngJ8Dk8nnW8nyTwL3kJLHqPxe/bFHHK31/jyoxz+3FIanSyQ9CVwPXAt8p2TZ7Ii4IyJWAW8DPgB8PSL+FhGdwM+AA0vq3xQRF0XEy6Sm9LrAzgCRvkUtj4hXIuIC4F5gp5J1VwI/iIiX8/J7gD0Gc2ARsYKUyD6ViyYDj0bETQPc1HLSB0NPL5M+rLbMcf8x8l/6GhwbEc9FxAt9LD8nIm6PiOeAbwHTlC9ED9L+wMkRcV9EPAscBezbo5Xy/yLihYi4FbiVlBxeI8eyL3BURDwTEUuA7wOfGYIYu50aEV3dr1FEzIuIFfncOY+UDNvXsP53I7X0lpASY1sFdacBp0TEsoh4HDixrw1ExBPAP5CS1pnAI5IukfSWXOUQ4DsRcU/+WzoO2EnS2DXE1RScFIanqRExOiK2jIgv9PiwerBkenPg8Yh4pqTsAdI3qdfVj4hXSN/6NgeQdKCkztzV8iTp2/CYknWX9fhAfaB73UGaAxyQpw8AzqlgG2NJ3yJ7+h7p2/fvcxfDzDK29eAAlj9AaoGM6aPuQGyet1e67VHAZiVlpXcLPU9qUfQ0JsfUc1tD+QH3mtdI6Y6zW0vOnW1Y82tSznH0V3fzHnGs8X3LX56mR8RY4D2k7sOT8+ItgR+VxP8o8AqpNdTUnBQaT+mH9HJgU0kblZRtQeru6NbdT4rShelxwHJJW5K6Jr4IvDkiRpOa5ipZd6yk0vkt8j4rjbfbJcB78jWBPYFzB7JBSTuSPvBed8ts/qb8lYiYAOwFHKFXr4X01WLoryUxvmR6C1Jr5FFSN9j6JXGtDbylpG5/211O+nAq3fYq4OF+1uvp0RxTz20t6716RYpjUbrd+HTg87x67tzNa8+daljBaz+0x/dVsaeIuIvUxbZdLnqQ1L02uuTfehGxgP7ftxHNSaGBRcSDwP8C35W0rqT3ADOA0tsg3yfpE7lL4kukfukbSP3jQboGgaSDefUPpttbgcMlrSPpU8C7gN8OMMyHSX3mpXH/DbgIOA9YGBFLy9mQpDdJ2hOYS+qrX9RLnT2VLnKLdA1kNekbYK+xlOkASZMkrQ/8J3BRpFtW/0q6kL+HpHVId4m9sWS9h4FW9X2X2PnAlyVtpXTb8XeAC3J3RtlyLPOA4yVtlBP+Ebz2PBhKG/LquSOlmxu2qdK+Ss0DvqR0c8UmwNf6qpjfryO6u4OUbsvdl3TuQ7ru9E1J78rLR0vaG4rX8zEqO1canpNC49uPdEFuOfAr4JiIuLJk+aWki8RPkPqYP5H72u8k9Tv/mfTh9W7gTz22vQCYSPomejywd0Q8NsD4zgQm5Wb6JSXlc/I+y+k6+rWkZ0jf7r5J6gI4uI+6E4ErSRc+/wz8OCKuzsu+CxydY/nqAI7hHNLF7IdI12QOh3Q3FPAF0nWcZaSWQ+ndSBfm/x+TdHMv2z0rb/s60g0AfwMOG0BcpQ7L+7+P1II6L29/yEXEbcB/AwtJ3963Jp0r1XY66RrDItKF78vo+xbTZ4D3A3+R9Bzpy9MtwJGQrqeRzqMLJT0N3Ab8c8n6xwDn5XPlE0N/KMNX910ZZjWVv7ndDbwtIp6udzzWeCR9nHQjxNvrHctI4paC1VzuTjkCmOuEYOWStIGkyfn3DOOA/yC1jm0IuaVgNSVpA1J31QPA5HxdxKxf+brLtaTuqueA3wBf6nH3nQ2Sk4KZmRXcfWRmZoWGGNyqL2PGjInW1tZ6h2Fm1lBuuummRyPiLb0ta+ik0Nrayo033ljvMMzMGoqkB/pa5u4jMzMrOCmYmVnBScHMzApOCmZmVnBSMDOzgpOCmZkVnBTMzKzgpGBmZgUnBTMzK1TtF82SziI9anFlRGxXUn4YcCjpiViXRcSRufwo0lPDVgOHR8TvqhWbVaZ15mUVr7vkhD2GMBIzq5ZqDnMxG/gh6bmoAEj6MDAF2D4iXpT01lw+ifSovG1JD+e+UtI782PxzMysRqrWfRQR1wGP9yj+PHBCRLyY66zM5VNID1x5MSLuBxYDO1UrNjMz612trym8E/igpAWSrpW0Yy4fS3r+breuXGZmZjVU61FSRwGbAjsDOwLzJE0YyAYkdQAdAC0tLXR2dg55kNa7aRMq783z+2TWGGqdFLqAiyM97m2hpFeAMcAyYHxJvXG57HUiYhYwC6C9vT3a2tqqG7EVps7t9S0py0kdfp/MGkGtu48uAT4MIOmdwBuAR4H5wL6S3ihpK2AisLDGsZmZNb1q3pJ6PrALMEZSF3AMcBZwlqTbgZeA6bnVcIekecCdwCrgUN95ZGZWe1VLChGxXx+LDuij/vHA8dWKx8zM+udfNJuZWcFJwczMCk4KZmZWcFIwM7OCk4KZmRWcFMzMrOCkYGZmBScFMzMrOCmYmVnBScHMzApOCmZmVnBSMDOzgpOCmZkVnBTMzKzgpGBmZgUnBTMzKzgpmJlZoWpJQdJZklbmR2/2XPYVSSFpTJ6XpNMkLZZ0m6QdqhWXmZn1rZothdnA5J6FksYD/wQsLSneHZiY/3UAp1cxLjMz60PVkkJEXAc83suiU4AjgSgpmwKcHckNwGhJLdWKzczMejeqljuTNAVYFhG3SipdNBZ4sGS+K5et6GUbHaTWBC0tLXR2dlYvYHuNaRNWV7yu3yezxlCzpCBpfeAbpK6jikXELGAWQHt7e7S1tQ1BdFaOqXOXVbzuSR1+n8waQS1bCm8HtgK6WwnjgJsl7QQsA8aX1B2Xy8zMrIZqdktqRCyKiLdGRGtEtJK6iHaIiIeA+cCB+S6knYGnIuJ1XUdmZlZd1bwl9Xzgz8DWkrokzVhD9d8C9wGLgZ8CX6hWXGZm1reqdR9FxH79LG8tmQ7g0GrFYmZm5fEvms3MrOCkYGZmBScFMzMrOCmYmVmhpr9otubVOvOyitddcsIeQxiJma2JWwpmZlZwUjAzs4KTgpmZFZwUzMys4KRgZmYFJwUzMys4KZiZWcFJwczMCk4KZmZWcFIwM7OCk4KZmRWq+eS1syStlHR7Sdn3JN0t6TZJv5I0umTZUZIWS7pH0j9XKy4zM+tbNVsKs4HJPcquALaLiPcAfwWOApA0CdgX2Dav82NJa1cxNjMz60XVkkJEXAc83qPs9xGxKs/eAIzL01OAuRHxYkTcT3pW807Vis3MzHpXz6Gz/xW4IE+PJSWJbl257HUkdQAdAC0tLXR2dlYzRisxbcLquuzX77FZ7dQlKUj6JrAKOHeg60bELGAWQHt7e7S1tQ1xdNaXqXOX1WW/J3X4PTarlZonBUkHAXsCu0ZE5OJlwPiSauNymZmZ1VBNb0mVNBk4EtgrIp4vWTQf2FfSGyVtBUwEFtYyNjMzq2JLQdL5wC7AGEldwDGku43eCFwhCeCGiDgkIu6QNA+4k9StdGhE1KcD28ysiVUtKUTEfr0Un7mG+scDx1crHjMz659/0WxmZgUnBTMzKzgpmJlZwUnBzMwKTgpmZlZwUjAzs4KTgpmZFZwUzMys4KRgZmYFJwUzMys4KZiZWcFJwczMCk4KZmZWcFIwM7NCWUlB0rurHYiZmdVfuS2FH0taKOkLkjauakRmZlY3ZSWFiPggsD/pOco3STpP0kerGpmZmdVc2U9ei4h7JR0N3AicBrxX6Zma34iIi3vWl3QWsCewMiK2y2WbAhcArcASYFpEPJG3cyrwMeB54KCIuHkwB2YjR+vMyyped8kJewxhJGYjX7nXFN4j6RTgLuAjwMcj4l15+pQ+VpsNTO5RNhO4KiImAlfleYDdgYn5Xwdw+gCOwczMhki51xT+G7gZ2D4iDu3+Fh8Ry4Gje1shIq4DHu9RPAWYk6fnAFNLys+O5AZgtKSW8g/DzMyGQrndR3sAL0TEagBJawHrRsTzEXHOAPa3WUSsyNMPAZvl6bHAgyX1unLZCnqQ1EFqTdDS0kJnZ+cAdm+DMW3C6nqHMGA+P8wGptykcCWwG/Bsnl8f+D3w95XuOCJCUlSw3ixgFkB7e3u0tbVVGoIN0NS5y+odwoCd1OHzw2wgyu0+WjciuhMCeXr9Cvb3cHe3UP5/ZS5fRrqzqdu4XGZmZjVUblJ4TtIO3TOS3ge8UMH+5gPT8/R04NKS8gOV7Aw8VdLNZGZmNVJu99GXgAslLQcEvA3YZ00rSDof2AUYI6kLOAY4AZgnaQbwADAtV/8t6XbUxaRbUg8e2GGYmdlQKCspRMRfJG0DbJ2L7omIl/tZZ78+Fu3aS90ADi0nFjMzq56yf7wG7Ej60dkoYAdJRMTZVYnKzMzqoqykIOkc4O1AJ9B9X2IATgpmZiNIuS2FdmBS7uYxM7MRqty7j24nXVw2M7MRrNyWwhjgTkkLgRe7CyNir6pEZWZmdVFuUji2mkGYmdnwUO4tqddK2hKYGBFXSlofWLu6oZmZWa2VO3T254CLgJ/korHAJdUKyszM6qPcC82HAh8Anob0wB3grdUKyszM6qPcpPBiRLzUPSNpFOl3CmZmNoKUmxSulfQNYL38bOYLgV9XLywzM6uHcpPCTOARYBHwb6QB7Hp94pqZmTWucu8+egX4af5nZmYjVLljH91PL9cQImLCkEdkZmZ1M5Cxj7qtC3wK2HTowzEzs3oq65pCRDxW8m9ZRPwA2KPKsZmZWY2V2320Q8nsWqSWw0CexdBze18GPkvqklpEetJaCzAXeDNwE/CZ0ttgzcys+sr9YP9+yfQqYAmvPkpzQCSNBQ4nDcX9gqR5wL6kx3GeEhFzJZ0BzABOr2QfZt1aZ15W8bpLTnBj2JpPuXcffbgK+11P0svA+sAK4CPAp/PyOaRB+JwUzMxqqNzuoyPWtDwiTi53hxGxTNJ/AUuBF4Dfk7qLnoyIVblaF2l8pd5i6QA6AFpaWujs7Cx31zZI0yas7r/SCOJzy5rRQO4+2hGYn+c/DiwE7h3oDiVtAkwBtgKeJP06enK560fELGAWQHt7e7S1tQ00BKvQ1LnL6h1CTZ3U4XPLmk+5SWEcsENEPAMg6Vjgsog4oIJ97gbcHxGP5G1dTBpsb7SkUbm1MA5ork8gM7NhoNxhLjYDSu8EeimXVWIpsLOk9SUJ2BW4E7ga2DvXmQ5cWuH2zcysQuW2FM4GFkr6VZ6fSroYPGARsUDSRcDNpDuZbiF1B10GzJV0XC47s5Ltm5lZ5cq9++h4SZcDH8xFB0fELZXuNCKOAY7pUXwfsFOl2zQzs8Ert/sI0q2jT0fEqUCXpK2qFJOZmdVJuY/jPAb4OnBULloH+EW1gjIzs/oot6XwL8BewHMAEbEc2KhaQZmZWX2UmxReioggD58taYPqhWRmZvVSblKYJ+knpN8SfA64Ej9wx8xsxCn37qP/ys9mfhrYGviPiLiiqpGZmVnN9ZsUJK0NXJkHxXMiMDMbwfrtPoqI1cArkjauQTxmZlZH5f6i+VlgkaQryHcgAUTE4VWJyszM6qLcpHBx/mdmZiPYGpOCpC0iYmlEVDTOkZmZNZb+rilc0j0h6ZdVjsXMzOqsv6SgkukJ1QzEzMzqr7+kEH1Mm5nZCNTfhebtJT1NajGsl6fJ8xERb6pqdGZmVlNrTAoRsXatAjEzs/obyPMUhoyk0ZIuknS3pLskvV/SppKukHRv/n+TesRmZtbM6pIUgFOB/4mIbYDtgbuAmcBVETERuCrPm5lZDdU8KeThMj5EfgZzRLwUEU8CU3j1uc9zSM+BNjOzGqpHS2Er4BHg55JukfSz/HyGzSJiRa7zELBZHWIzM2tq5Q5zMdT73AE4LCIWSDqVHl1FERGSer0FVlIH0AHQ0tJCZ2dnteO1bNqE1fUOoaZ8blkzqkdS6AK6ImJBnr+IlBQeltQSESsktQAre1s5ImYBswDa29ujra2tFjEbMHXusnqHUFMndfjcsuZT8+6jiHgIeFDS1rloV+BOYD4wPZdNBy6tdWxmZs2uHi0FgMOAcyW9AbgPOJiUoOZJmgE8AEyrU2xmZk2rLkkhIjqB9l4W7VrrWMzM7FX1+p2CmZkNQ04KZmZWqNc1BbNhr3XmZYNaf8kJewxRJGa145aCmZkVnBTMzKzgpGBmZgUnBTMzKzgpmJlZwUnBzMwKTgpmZlZwUjAzs4KTgpmZFZwUzMys4KRgZmYFj31kViWDGTvJ4yZZvTgpmJnVyXD84uDuIzMzK9QtKUhaW9Itkn6T57eStEDSYkkX5Ed1mplZDdWzpfDvwF0l8ycCp0TEO4AngBl1icrMrInV5ZqCpHHAHsDxwBGSBHwE+HSuMgc4Fji9WjH4ASpmZq9XrwvNPwCOBDbK828GnoyIVXm+Cxjb24qSOoAOgJaWFjo7OysKYNqE1RWt163S/Taywb5mVr5mPL+a0WD+pqp1jtQ8KUjaE1gZETdJ2mWg60fELGAWQHt7e7S1tVUUx9S5yypar9tJHZXtt5EN9jWz8jXj+dWMBvM3Va1zpB4thQ8Ae0n6GLAu8CbgVGC0pFG5tTAO8CeQmVmN1fxCc0QcFRHjIqIV2Bf4Q0TsD1wN7J2rTQcurXVsZmbNbjj9TuHrpIvOi0nXGM6sczxmZk2nrr9ojohrgGvy9H3ATvWMx8ys2Q2nloKZmdWZk4KZmRWcFMzMrOCkYGZmBScFMzMrOCmYmVnBScHMzApOCmZmVnBSMDOzgpOCmZkV6jrMhZn1bjg+0N2ag1sKZmZWcFIwM7OCk4KZmRWcFMzMrOCkYGZmhZonBUnjJV0t6U5Jd0j691y+qaQrJN2b/9+k1rGZmTW7erQUVgFfiYhJwM7AoZImATOBqyJiInBVnjczsxqqeVKIiBURcXOefga4CxgLTAHm5GpzgKm1js3MrNnV9cdrklqB9wILgM0iYkVe9BCwWR/rdAAdAC0tLXR2dla072kTVle0XrdK99vIBvuaWW0047nZqAbzN1Wt97luSUHShsAvgS9FxNOSimUREZKit/UiYhYwC6C9vT3a2toq2v/UucsqWq/bSR2V7beRDfY1s9poxnOzUQ3mb6pa73NdkoKkdUgJ4dyIuDgXPyypJSJWSGoBVtYjtpFsMEMnmFlzqMfdRwLOBO6KiJNLFs0Hpufp6cCltY7NzKzZ1aOl8AHgM8AiSd2dYt8ATgDmSZoBPABMq0NsZg3Pg+nZYNQ8KUTE9YD6WLxrLWMxM7PX8i+azcys4OcpmNmw4G6v4cEtBTMzK7ilYGYF37ZsbimYmVnBScHMzApOCmZmVvA1BTOzCo3EazBuKZiZWcFJwczMCu4+MrOmNhK7gAbDLQUzMys4KZiZWcHdR2bW8NwFNHTcUjAzs4KTgpmZFZwUzMysMOyuKUiaDJwKrA38LCJOqHNIQ879n2Y2XA2rloKktYEfAbsDk4D9JE2qb1RmZs1jWCUFYCdgcUTcFxEvAXOBKXWOycysaQy37qOxwIMl813A35VWkNQBdOTZZyXdU+G+xgCPVrguOrHSNetqUMfcoHzMzaHpjlknDuqYt+xrwXBLCv2KiFnArMFuR9KNEdE+BCE1DB9zc/AxN4dqHfNw6z5aBowvmR+Xy8zMrAaGW1L4CzBR0laS3gDsC8yvc0xmZk1jWHUfRcQqSV8Efke6JfWsiLijSrsbdBdUA/IxNwcfc3OoyjErIqqxXTMza0DDrfvIzMzqyEnBzMwKIz4pSJos6R5JiyXN7GX5GyVdkJcvkNRa+yiHVhnHfISkOyXdJukqSX3es9wo+jvmknqflBSSGv72xXKOWdK0/F7fIem8Wsc41Mo4t7eQdLWkW/L5/bF6xDlUJJ0laaWk2/tYLkmn5dfjNkk7DHqnETFi/5EuVv8fMAF4A3ArMKlHnS8AZ+TpfYEL6h13DY75w8D6efrzzXDMud5GwHXADUB7veOuwfs8EbgF2CTPv7XecdfgmGcBn8/Tk4Al9Y57kMf8IWAH4PY+ln8MuBwQsDOwYLD7HOkthXKGzZgCzMnTFwG7SlINYxxq/R5zRFwdEc/n2RtIvwdpZOUOj/Jt4ETgb7UMrkrKOebPAT+KiCcAImJljWMcauUccwBvytMbA8trGN+Qi4jrgMfXUGUKcHYkNwCjJbUMZp8jPSn0NmzG2L7qRMQq4CngzTWJrjrKOeZSM0jfNBpZv8ecm9XjI2KkDFFbzvv8TuCdkv4k6YY8AnEjK+eYjwUOkNQF/BY4rDah1c1A/977Nax+p2C1JekAoB34x3rHUk2S1gJOBg6qcyi1NorUhbQLqTV4naR3R8STdY2quvYDZkfE9yW9HzhH0nYR8Uq9A2sUI72lUM6wGUUdSaNITc7HahJddZQ1VIik3YBvAntFxIs1iq1a+jvmjYDtgGskLSH1vc5v8IvN5bzPXcD8iHg5Iu4H/kpKEo2qnGOeAcwDiIg/A+uSBssbqYZ8aKCRnhTKGTZjPjA9T+8N/CHyFZwG1e8xS3ov8BNSQmj0fmbo55gj4qmIGBMRrRHRSrqOsldE3FifcIdEOef2JaRWApLGkLqT7qtlkEOsnGNeCuwKIOldpKTwSE2jrK35wIH5LqSdgaciYsVgNjiiu4+ij2EzJP0ncGNEzAfOJDUxF5Mu6Oxbv4gHr8xj/h6wIXBhvqa+NCL2qlvQg1TmMY8oZR7z74B/knQnsBr4WkQ0bCu4zGP+CvBTSV8mXXQ+qJG/5Ek6n5TYx+TrJMcA6wBExBmk6yYfAxYDzwMHD3qfDfx6mZnZEBvp3UdmZjYATgpmZlZwUjAzs4KTgpmZFZwUzMys4KRgTUfSakmdkm6XdKGk9Qe4/rMDrD9b0t69lLdLOi1PHyTph3n6EEkHlpRvPpD9mQ2Gk4I1oxcioi0itgNeAg4pXZh/CFT1v42IuDEiDu+l/IyIODvPHgQ4KVjNOClYs/sj8A5JrXmc/rOB24HxkvaTtCi3KE4sXUnSKfkZBVdJeksu+5ykv0i6VdIve7RAdpN0o6S/Stoz199F0m96BiTpWElfza2LduDc3LLZQ9IlJfU+KulXQ/+SWDNzUrCmlce62h1YlIsmAj+OiG2Bl0nDbH8EaAN2lDQ119uA9AvabYFrSb8yBbg4InaMiO2Bu0jj8HRrJQ39vAdwhqR1+4svIi4CbgT2j4g20q9Xt+lOQqRfr5414AM3WwMnBWtG60nqJH3gLiUNdQLwQB6THmBH4JqIeCQPqX4u6YEnAK8AF+TpXwD/kKe3k/RHSYuA/YFtS/Y5LyJeiYh7SeMPbTPQoPNwDeeQhoYeDbyfxh/23IaZET32kVkfXsjfvAt5DKjnKtxe91gxs4GpEXGrpIPIg9H1qNPXfLl+Dvya9KCgC3PCMhsybimY9W4h8I+SxkhamzRO/7V52VqkEXUBPg1cn6c3AlZIWofUUij1KUlrSXo76XGS95QZxzN5uwBExHLS08SOJiUIsyHlloJZLyJihdKD4a8mPf/2soi4NC9+DthJ0tHASmCfXP4tYAFpqOYFlHyYk7qpFpIeFXlIRPytzKe+ziZdg3gBeH9EvEDqynpLRNw1iEM065VHSTVrMPn3DLdExJn9ViBfPDoAAAA7SURBVDYbICcFswYi6SZSS+WjI+CJeTYMOSmYmVnBF5rNzKzgpGBmZgUnBTMzKzgpmJlZwUnBzMwK/x8YNNb019hWcgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "bins = 20\n",
+    "n, b, patches = plt.hist(x=train_prob, bins=bins)\n",
+    "plt.grid(axis='y', alpha=0.75)\n",
+    "plt.xlabel('Probability')\n",
+    "plt.ylabel('Frequency')\n",
+    "plt.title('Probability Distribution of Training Set')\n",
+    "n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So comparing the distributions of the training and test sets, they are similar, but the test set has more of a \"clump\" in the 0.4-0.6 range, which means there is more to \"learn\" as expected.  But this also means that we can use predict_proba to identify this \"yellow\" or inconclusive set of predictions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quick Sanity Check\n",
+    "Let's do a sanity check by doing the predictions and calculating the classification report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_pred = estimator.predict(x_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "         red       0.89      0.92      0.90       145\n",
+      "       green       0.76      0.70      0.73        54\n",
+      "\n",
+      "    accuracy                           0.86       199\n",
+      "   macro avg       0.83      0.81      0.82       199\n",
+      "weighted avg       0.86      0.86      0.86       199\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(metrics.classification_report(y_test, y_pred, target_names=['red', 'green']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_train_pred = estimator.predict(x_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "         red       0.92      0.95      0.93       577\n",
+      "       green       0.85      0.77      0.81       217\n",
+      "\n",
+      "    accuracy                           0.90       794\n",
+      "   macro avg       0.88      0.86      0.87       794\n",
+      "weighted avg       0.90      0.90      0.90       794\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(metrics.classification_report(y_train, y_train_pred, target_names=['red', 'green']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Good, my training set performed better than my test set (so I can be more confident that it is a \"clean\" test set and that my analysis above is valid)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
If you were interested, this notebook demonstrates how you can take a look at the features (phrases) and coefficients assigned by the classifier. In addition it displays the distribution of probabilities across a test set (and the initial training set) to see how useful it would be to use predict_proba to give report a confidence level to the user in the classification. You can see the notebook in action at https://nbviewer.jupyter.org/github/rbuccigrossi/srt-fbo-scraper/blob/master/eda/confidence_experiments.ipynb