### PR TITLE
Fix to SAM API pagination

### DIFF
--- a/tests/sam_utils_test.py
+++ b/tests/sam_utils_test.py
@@ -14,6 +14,8 @@ from tests import mock_opps
 from utils.sam_utils import get_org_info, write_zip_content, get_notice_data, get_notice_type,\
                             schematize_opp, naics_filter, get_dates_from_opp, find_yesterdays_opps
 
+from utils.request_utils import  get_opp_request_details, get_opps
+
 
 class SamUtilsTestCase(unittest.TestCase):
 
@@ -217,6 +219,26 @@ class SamUtilsTestCase(unittest.TestCase):
         expected = ([],
                     False)
         self.assertEqual(result, expected)
+
+
+    def test_api_pagination(self):
+        uri, params, headers = get_opp_request_details()
+        params['postedFrom'] = '01/26/2020'
+        params['postedTo'] = '01/26/2020'
+        params['limit'] = 10
+
+        # dict of opportunites - Page 1
+        opps, total_pages = get_opps(uri, params, headers)
+        self.assertGreater(total_pages, 1)
+
+        # dict of opportunites - Page 2
+        page = 2
+        params.update({'offset': str( page * params['limit'] )})
+        opps_2, total_pages_2 = get_opps(uri, params, headers)
+        self.assertGreater(total_pages_2, 1)
+        self.assertNotEqual(opps[0]['noticeId'], opps_2[0]['noticeId'], "We should get different notice IDs on different pages, instead got {} and {}".format(opps[0]['noticeId'], opps_2[0]['noticeId']) )
+
+
 
 
 if __name__ == '__main__':

--- a/utils/get_opps.py
+++ b/utils/get_opps.py
@@ -35,7 +35,7 @@ def get_yesterdays_opps(filter_naics = True):
 
     page = 1
     while page < int(total_pages):
-        params.update({'page': str(page)})
+        params.update({'offset': str( page * params['limit'] )})
         _opps, _ = get_opps(uri, params, headers)
         _opps, _is_more_opps = find_yesterdays_opps(_opps)
         opps.extend(_opps)


### PR DESCRIPTION
I did some testing and it appears that when paging through the search API results the code is looking at the same first page of results each time.

https://api.sam.gov/prod/opportunities/v1/search uses "offset" rather than "page" to pull records that didn't fit in the initial request limit so I added a test and made a small code change.



