### PR TITLE
Unit test fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ Local setup requires:
  - PostgreSQL 9.6.8 (newer versions are likely fine)
 
  Once you've got the above prerequisites met, you'll need to install several OS-specific dependencies to get Python's `textract` library to work. This library is responsible for extracting the text from the myriad solicitation documents. It does so by calling several different OS-specific packages. See their [documentation](https://textract.readthedocs.io/en/stable/installation.html) for more details on the packages you'll need to install given your OS.
-
+ As of January 28, the Linux/Debian prerequisites for textract are:
+ ```bash
+apt-get install python-dev libxml2-dev libxslt1-dev antiword unrtf poppler-utils pstotext \
+                            tesseract-ocr flac ffmpeg lame libmad0 libsox-fmt-mp3 sox libjpeg-dev swig
+ ```
 #### Local Implementation
 
 Now that you have Python, PostgreSQL, and the textract dependencies, you can run the scan locally within a virtual environment (using [venv](https://docs.python.org/3.6/library/venv.html)). Doing so will create a database with the following connection string: `postgresql+psycopg2://localhost/test`. Make sure postgres is already running in the background and accepting connections on localhost.

--- a/main.py
+++ b/main.py
@@ -34,5 +34,8 @@ def main():
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO,
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s') 
+                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    fh = logging.FileHandler(r'smartie-logger.log')
+    fh.setFormatter( logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    logger.addHandler(fh)
     main()

--- a/tests/get_doc_text_test.py
+++ b/tests/get_doc_text_test.py
@@ -20,11 +20,13 @@ class GetDocTextTestCase(unittest.TestCase):
         if not os.path.exists(out_path):
             os.mkdir(out_path)
         self.abs_out_path = os.path.abspath(out_path)
-        
+
         # refer to fixture
-        if 'tests' not in os.getcwd():
-            self.temp_outfile_path_doc = os.path.join('tests', 'fixtures', 'test.doc')
-        else:
+        if 'fixtures' in os.getcwd():
+            self.temp_outfile_path_doc = os.path.join('test.doc')
+        elif '_trial_temp' in os.getcwd():  # running in pycharm
+            self.temp_outfile_path_doc = os.path.join('..', 'fixtures', 'test.doc')
+        elif 'tests' in os.getcwd():
             self.temp_outfile_path_doc = os.path.join('fixtures', 'test.doc')
 
         # create a mock file w/o extension

--- a/utils/db/db_utils.py
+++ b/utils/db/db_utils.py
@@ -122,7 +122,8 @@ def fetch_notice_type_id(notice_type, session):
     '''
     try:
         notice_type_id = session.query(db.NoticeType.id).filter(db.NoticeType.notice_type==notice_type).first().id
-    except AttributeError:
+    except AttributeError as e:
+        logger.error("Requested notice type {} was not found.".format(notice_type))
         return
     
     return notice_type_id
@@ -187,6 +188,10 @@ def insert_data(session, data):
     for opp in data:
         notice_type = opp.pop('notice type')
         notice_type_id = fetch_notice_type_id(notice_type, session)
+
+        if notice_type_id == None:
+            logger.error("Notice type was not found when inserting record into the notice table.")
+            continue
 
         attachments = opp.pop('attachments')
         agency = opp.pop('agency')

--- a/utils/get_doc_text.py
+++ b/utils/get_doc_text.py
@@ -17,12 +17,15 @@ def get_doc_text(file_name, rm = True):
     #ShellError with antiword occurs when an rtf is saved with a doc extension
     except textract.exceptions.ShellError as e:
         err_message = str(e)
-        if 'antiword' in err_message and file_name.endswith('.doc'):
-            new_name = file_name.replace('.doc','.rtf')
-            os.rename(file_name, new_name)
-            b_text = textract.process(new_name, 
-                                      encoding = 'utf-8', 
-                                      errors = 'ignore')
+        try:
+            if 'antiword' in err_message and file_name.endswith('.doc'):
+                new_name = file_name.replace('.doc','.rtf')
+                os.rename(file_name, new_name)
+                b_text = textract.process(new_name,
+                                          encoding = 'utf-8',
+                                          errors = 'ignore')
+        except textract.exceptions.ShellError as ex:
+            logger.error("Error extracting text from a DOC file. Check that all dependencies of textract are installed.\n{}".format(ex))
     except textract.exceptions.MissingFileError as e:
         b_text = None
         logger.error(f"Couldn't textract {file_name} since the file couldn't be found: \

--- a/utils/get_opps.py
+++ b/utils/get_opps.py
@@ -61,9 +61,12 @@ def get_docs(opp_id, out_path):
     try:
         with requests_retry_session() as session:
             r = session.get(uri, timeout = 200)
+
     except Exception as e:
         logger.error(f"Exception {e} getting opps from {uri}", exc_info=True)
-        sys.exit(1)
+        # don't exit....would be better to keep going so we can process the other opportunities in this batch.
+        # sys.exit(1)
+        return []
     if r.ok:
         file_list = write_zip_content(r.content, out_path)
     else:
@@ -93,6 +96,7 @@ def transform_opps(opps, out_path):
     """
     transformed_opps = []
     for opp in opps:
+        logger.info("transforming notice {}".format(opp['noticeId']))
         schematized_opp = schematize_opp(opp)
         if not schematized_opp:
             continue


### PR DESCRIPTION
DB test setup change so tests will work properly with pre-populated DB
Added check and test to make sure no notices are inserted with a null notice type
No longer exit if there is an error downloading an attachment.
Write logs to a smartie-logger.log file in addition to stdout
Made the unit tests smarter about finding sample files in the fixtures directory.