### PR TITLE
Adding Cannot Evaluate Review Rec Value

### DIFF
--- a/src/fbo_scraper/db/db_utils.py
+++ b/src/fbo_scraper/db/db_utils.py
@@ -1,12 +1,13 @@
 from contextlib import contextmanager
 from datetime import datetime
 import json
-from typing import Union
+from typing import List, Union
 import logging
 import os
 import sys
 from copy import deepcopy
 from random import random
+from enum import Enum
 
 import dill as pickle
 from sqlalchemy import create_engine, func, case, inspect
@@ -23,6 +24,12 @@ import functools
 CACHE_SIZE=256
 
 logger = logging.getLogger(__name__)
+
+class PredictionEnum(Enum):
+    compliant = 0
+    non_compliant = 1
+    not_applicable = 2
+    cannot_evaluate = 3
 
 def object_as_dict(obj):
     '''
@@ -333,19 +340,17 @@ def handle_attachments(opportunity: dict, solicitation: Solicitation, now: datet
         solicitation.attachments.append(attachment)
         parse_status_text = "successfully parsed" if doc['machine_readable'] else "processing error"
         parseStatus.append({"id": attachment.id, "name": doc['filename'], "status": parse_status_text, "postedDate": now_datetime_string, "attachment_url": doc['url'] })
-
-    solicitation.na_flag = not is_machine_readable(attachments) if attachments else True
-
+    
     solicitation.parseStatus = parseStatus
 
     return prediction
 
-def is_machine_readable(attachments: list) -> bool:
+def is_machine_readable(attachments: List[db.Attachment]) -> bool:
     """
     Determine if any of the attachments are machine readable.
 
     Args:
-        attachments (list): List of attachment dicts from the API
+        attachments (list [Attachment]): List of attachment dicts from the API
 
     Returns:
         bool: True if any attachment is machine readable, False otherwise.
@@ -354,28 +359,33 @@ def is_machine_readable(attachments: list) -> bool:
         return False
 
     for attachment in attachments:
-        if attachment.get('machine_readable'):
+        if attachment.machine_readable:
             return True
     return False
 
 def apply_predictions_to(solicitation: Solicitation, predicition: int):
     new_prediction = deepcopy(solicitation.predictions)  # make a copy - if you only chagne the props then SQAlchamy won't know the object changed
 
-    if solicitation.na_flag:
+    prediction_result = determine_prediction_value(solicitation, predicition)
+
+    if prediction_result == PredictionEnum.not_applicable:
         solicitation.reviewRec = "Not Applicable"
         new_prediction['value'] = "grey"
         new_prediction['508'] = "grey"
+    elif prediction_result == PredictionEnum.compliant:
+        new_prediction['value'] = "green"
+        new_prediction['508'] = "green"
+        solicitation.reviewRec = "Compliant"
+        solicitation.compliant = 1
+    elif prediction_result == PredictionEnum.non_compliant:
+        new_prediction['value'] = "red"
+        new_prediction['508'] = "red"
+        solicitation.reviewRec = "Non-compliant (Action Required)"
+        solicitation.compliant = 0
     else:
-        if predicition != 0:
-            new_prediction['value'] = "green"
-            new_prediction['508'] = "green"
-            solicitation.reviewRec = "Compliant"
-            solicitation.compliant = 1
-        else:
-            new_prediction['value'] = "red"
-            new_prediction['508'] = "red"
-            solicitation.reviewRec = "Non-compliant (Action Required)"
-            solicitation.compliant = 0
+        new_prediction['value'] = "yellow"
+        new_prediction['508'] = "yellow"
+        solicitation.reviewRec = "Cannot Evaluate (Review Required)"
 
     # add a random estar prediction
     # TODO: properly compute estar prediction
@@ -387,6 +397,20 @@ def apply_predictions_to(solicitation: Solicitation, predicition: int):
 
     new_prediction['history'].append( { "date": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"), "value": new_prediction['value'], "508": new_prediction['value'], "estar": estar}  )
     solicitation.predictions = new_prediction
+
+def determine_prediction_value(solicitation: Solicitation, predicition: int):
+    pred = None
+
+    if solicitation.na_flag:
+        pred = PredictionEnum.not_applicable
+    else:
+        if not solicitation.attachments or not is_machine_readable(solicitation.attachments):
+            pred = PredictionEnum.cannot_evaluate
+        elif predicition != 0:
+            pred = PredictionEnum.compliant
+        else:
+            pred = PredictionEnum.non_compliant
+    return pred
 
 def insert_data_into_solicitations_table(session, data):
     '''

--- a/src/fbo_scraper/main.py
+++ b/src/fbo_scraper/main.py
@@ -104,7 +104,7 @@ def actual_main():
 
     # fast mode
     # limit=40
-    updateOld=False
+    # updateOld=False
     # skip_attachemnts=True
 
     #db reload for last week
@@ -133,7 +133,7 @@ if __name__ == '__main__':
 
     # fast mode
     # limit=40
-    updateOld=False
+    # updateOld=False
     # skip_attachemnts=True
 
     #db reload for last week

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -143,8 +143,8 @@ class DBTestCase(unittest.TestCase):
         assert len(result) > 0, "We should have at least one result."
         assert result[0]['solNum'] == expected[0]['solNum'], "The solNum should match."
         assert result[0]['agency'] == expected[0]['agency'], "The agency should match."
-        # Test verifying update for Ticket 33: https://trello.com/c/9Voxvpd1
-        assert result[0]['reviewRec'] == 'Not Applicable'
+        # Test verifying update for Ticket 67: https://trello.com/c/wAhW6CgG
+        assert result[0]['reviewRec'] == 'Cannot Evaluate (Review Required)'
 
 
     def test_insert_data_into_solicitations_table_with_new_notice_type(self):


### PR DESCRIPTION
# Issue
We initially adjusted the 0 Documents and Machine Unreadable Excluded Solicitations to be included in the Not Applicable. However, the issue we didn’t realize is that the N/A value was to indicate that 508 does not apply to this specific solicitation.

# Updates
- Added a new reviewRec category (Cannot Evaluate)
- Implemented new unit tests