### PR TITLE
Remove duplicate solicitation numbers in Opportunity Gathering

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     imbalanced-learn
     nltk
     numpy
+    pandas
     psycopg2-binary
     python-dateutil
     python-json-logger

--- a/src/fbo_scraper/db/db_utils.py
+++ b/src/fbo_scraper/db/db_utils.py
@@ -462,12 +462,8 @@ def insert_data_into_solicitations_table(session, data):
                 )
             ).lower()
 
-            if not sol_existed_in_db:
-                logger.info("Inserting {}".format(sol.solNum))
-                session.add(sol)
-            else:
-                #print("Updating {}".format(sol.solNum))
-                logger.info("Updating {}".format(sol.solNum))
+
+            insert_data_into(session, sol, sol_existed_in_db)
 
             opp_count += 1
 
@@ -486,6 +482,13 @@ def insert_data_into_solicitations_table(session, data):
         )
     )
 
+def insert_data_into(db_session, from_sol_model, existed_in_db):
+    if not existed_in_db:
+        logger.info("Inserting {}".format(from_sol_model.solNum))
+        db_session.add(from_sol_model)
+    else:
+        #print("Updating {}".format(sol.solNum))
+        logger.info("Updating {}".format(from_sol_model.solNum))
 
 def get_validation_count(session):
     """
@@ -577,7 +580,7 @@ def fetch_solicitations_by_solnbr(solnbr: str, session, as_dict: bool=True) -> U
     solicitation = session.query(db.Solicitation).filter(db.Solicitation.solNum == solnbr).first()
     
     if as_dict:
-        sol_dict = object_as_dict(solicitation)
+        sol_dict = object_as_dict(solicitation) if solicitation else None
     else:
         sol_dict = solicitation
 
@@ -598,7 +601,7 @@ def fetch_notice_by_id(notice_id, session):
         notice = session.query(db.Notice).get(notice_id)
     except AttributeError:
         return
-    notice_dict = object_as_dict(notice)
+    notice_dict = object_as_dict(notice) if notice else None
 
     return notice_dict
 
@@ -676,7 +679,8 @@ def fetch_notice_attachments(notice_id, session):
     attachments = session.query(db.Attachment).filter(
         db.Attachment.notice_id == notice_id
     )
-    attachment_dicts = [object_as_dict(a) for a in attachments]
+
+    attachment_dicts = [object_as_dict(a) for a in attachments] if attachments else []
 
     return attachment_dicts
 

--- a/src/fbo_scraper/get_opps.py
+++ b/src/fbo_scraper/get_opps.py
@@ -9,6 +9,7 @@ import hashlib
 import urllib
 import errno
 from pathlib import Path
+import pandas as pd
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from fbo_scraper.get_doc_text import get_doc_text
@@ -299,6 +300,12 @@ def transform_opps(opps, out_path, skip_attachments=False):
                 ]
                 schematized_opp["attachments"].extend(attachment_data)
         transformed_opps.append(schematized_opp)
+    
+    # Removing duplicate solicitation numbers resulting in a unique solNum constraint violation
+    df = pd.DataFrame(transformed_opps)
+    df.drop_duplicates(subset=['solnbr'], inplace=True)
+    transformed_opps = df.to_dict('records')
+
     return transformed_opps
 
 

--- a/tests/mock_opps.py
+++ b/tests/mock_opps.py
@@ -437,6 +437,37 @@ mock_schematized_opp_two = {
     "emails": ["jacob.trejo.1@us.af.mil"],
 }
 
+mock_schematized_solnum_constraint_error = [
+    {
+    "notice type": "Special Notice",
+    "solnbr": "ATC1234",
+    "agency": "DEPT OF DEFENSE",
+    "compliant": 0,
+    "office": "DEPT OF THE AIR FORCE",
+    "attachments": [],
+    "classcod": None,
+    "naics": "5",
+    "subject": "Gartner Licenses",
+    "url": "https://beta.sam.gov/opp/bdc8e589bfe24772a226b98b16239cb7/view",
+    "setaside": "",
+    "emails": ["jacob.trejo.1@us.af.mil"],
+    },
+    {
+    "notice type": "Special Notice",
+    "solnbr": "ATC1234",
+    "agency": "DEPT OF DEFENSE",
+    "compliant": 0,
+    "office": "DEPT OF THE AIR FORCE",
+    "attachments": [],
+    "classcod": None,
+    "naics": "5",
+    "subject": "Gartner Licenses",
+    "url": "https://beta.sam.gov/opp/bdc8e589bfe24772a226b98b16239cb7/view",
+    "setaside": "",
+    "emails": ["jacob.trejo.1@us.af.mil"],
+    }
+]
+
 mock_attachment_data = {
     "text": "test",
     "filename": "test.txt",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,8 +7,8 @@ import logging
 sys.path.append( os.path.dirname( os.path.dirname( os.path.abspath(__file__) ) ) )
 from tests.mock_opps import mock_schematized_opp_one
 from fbo_scraper.db.db import Notice, NoticeType, Attachment, Model, now_minus_two, Solicitation
-from fbo_scraper.db.db_utils import (session_scope, insert_data_into_solicitations_table,
-                              DataAccessLayer, clear_data, object_as_dict, fetch_notice_type_id,
+from fbo_scraper.db.db_utils import (insert_data_into_solicitations_table,
+                              clear_data, object_as_dict, fetch_notice_type_id,
                               insert_model, insert_notice_types, retrain_check,
                               get_validation_count, get_trained_count,
                               get_validated_untrained_count, fetch_validated_attachments,
@@ -67,13 +67,13 @@ class DBTestCase(unittest.TestCase):
         self.dal.create_test_postgres_db()
         self.dal.connect()
 
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_notice_types(session)
 
         self.maxDiff = None
 
     def tearDown(self):
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             clear_data(session)
         close_all_sessions()
         self.dal.drop_test_postgres_db()
@@ -82,7 +82,7 @@ class DBTestCase(unittest.TestCase):
 
     def test_insert_bad_notice(self):
         call_count = 0
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             # intentionally bad notice type
             data = mock_schematized_opp_one.copy()
             data['notice type'] = "not to be found"
@@ -97,7 +97,7 @@ class DBTestCase(unittest.TestCase):
             assert call_count >= 1, "We should get one warning when adding a notice with a new notice type."
 
     def test_insert_notice_types(self):
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_notice_types(session)
 
         types = [
@@ -108,7 +108,7 @@ class DBTestCase(unittest.TestCase):
         ]
         notice_type_ids = []
         for notice_type in types:
-            with session_scope(self.dal) as session:
+            with self.dal.Session.begin() as session:
                 notice_type_id = (
                     session.query(NoticeType.id)
                     .filter(NoticeType.notice_type == notice_type)
@@ -122,10 +122,10 @@ class DBTestCase(unittest.TestCase):
         self.assertEqual(result, expected)
         
     def test_insert_data_into_solicitations_table(self):
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_data_into_solicitations_table(session, self.data)
         result = []
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             solicitations = session.query(Solicitation).filter(Solicitation.solNum == self.data[0]['solnbr'])
             for s in solicitations:
                 notice = object_as_dict(s)
@@ -162,10 +162,10 @@ class DBTestCase(unittest.TestCase):
         opp = self.data[0].copy()
         nnt = "new notice type"
         opp["notice type"] = nnt
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_data_into_solicitations_table(session, [opp])
         result = []
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             notices = session.query(Notice).all()
             for n in notices:
                 notice = object_as_dict(n)
@@ -177,10 +177,10 @@ class DBTestCase(unittest.TestCase):
         results = {"c": "d"}
         params = {"a": "b"}
         score = 0.99
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_model(session, results=results, params=params, score=score)
         result = []
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             models = session.query(Model).all()
             for m in models:
                 model = object_as_dict(m)
@@ -197,53 +197,53 @@ class DBTestCase(unittest.TestCase):
         results = {"c": "d"}
         params = {"a": "b"}
         score = 0.99
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_model(session, results=results, params=params, score=score)
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             score = fetch_last_score(session)
         result = score
         expected = 0.99
         self.assertEqual(result, expected)
 
     def test_get_validation_count(self):
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_data_into_solicitations_table(session, self.data)
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             result = get_validation_count(session)
         expected = 0
         self.assertEqual(result, expected)
 
     def test_get_trained_count(self):
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_data_into_solicitations_table(session, self.data)
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             result = get_trained_count(session)
         expected = 0
         self.assertEqual(result, expected)
 
     def test_get_validated_untrained_count(self):
         result = None
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_data_into_solicitations_table(session, self.data)
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             result = get_validated_untrained_count(session)
         expected = 0
         self.assertEqual(result, expected)
 
     def test_retrain_check(self):
         result = None
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_data_into_solicitations_table(session, self.data)
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             result = retrain_check(session)
         expected = False
         self.assertEqual(result, expected)
 
     def test_fetch_validated_attachments(self):
         attachments = None
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_data_into_solicitations_table(session, self.data)
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             attachments = fetch_validated_attachments(session)
         result = len(attachments)
         # 993 since that's how many docs were initially labeled
@@ -252,9 +252,9 @@ class DBTestCase(unittest.TestCase):
 
     def test_fetch_solicitations_by_solnbr(self):
         notices = None
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_data_into_solicitations_table(session, self.data)
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             notices = fetch_solicitations_by_solnbr('test', session)
         result = len(notices)
         expected = 28 # Amount of keys in dict
@@ -262,13 +262,12 @@ class DBTestCase(unittest.TestCase):
 
     def test_fetch_solicitations_by_solnbr_bogus_solnbr(self):
         notices = []
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_data_into_solicitations_table(session, self.data)
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             notices = fetch_solicitations_by_solnbr("notexist", session)
-        result = len(notices)
-        expected = 0
-        self.assertEqual(result, expected)
+        
+        self.assertEqual(notices, None)
 
 
 if __name__ == '__main__':

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -6,8 +6,8 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from tests.mock_opps import mock_schematized_opp_two
 from fbo_scraper.db.db import Notice, NoticeType, Solicitation, Attachment, Model, now_minus_two
-from fbo_scraper.db.db_utils import session_scope, insert_data_into_solicitations_table, \
-    DataAccessLayer, insert_notice_types, update_solicitation_history, search_for_agency, handle_attachments, apply_predictions_to
+from fbo_scraper.db.db_utils import insert_data_into_solicitations_table, \
+    DataAccessLayer, insert_notice_types, update_solicitation_history, search_for_agency, handle_attachments, apply_predictions_to,create_new_or_exisiting_sol, insert_data_into
 
 from fbo_scraper.db.connection import get_db_url
 
@@ -28,12 +28,12 @@ class DBTestCase(unittest.TestCase):
         self.dal.create_test_postgres_db()
         self.dal.connect()
 
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             insert_notice_types(session)
 
 
     def tearDown(self):
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             clear_data(session)
         close_all_sessions()
         self.dal.drop_test_postgres_db()
@@ -41,11 +41,12 @@ class DBTestCase(unittest.TestCase):
         self.data = None
 
     def test_insert_data_into_solicitations_table(self):
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             try:
                 insert_data_into_solicitations_table(session, [mock_schematized_opp_two])
             except Exception as e:
                 print (e)
+        
 
 def test_update_solicitation_history():
     # Create a mock solicitation object

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -6,10 +6,6 @@ import pytest
 import logging
 sys.path.append( os.path.dirname( os.path.dirname( os.path.abspath(__file__) ) ) )
 
-from fbo_scraper.db.db_utils import session_scope, DataAccessLayer, clear_data
-from fbo_scraper.db.connection import get_db_url
-
-from sqlalchemy.orm.session import close_all_sessions
 
 def test_end_to_end(db_access_layer):
 

--- a/tests/test_get_opps.py
+++ b/tests/test_get_opps.py
@@ -144,6 +144,11 @@ class GetOppsTestCase(unittest.TestCase):
         expected = [mock_opps.mock_transformed_opp_one]
         self.assertEqual(result, expected)
 
+    @patch('fbo_scraper.get_opps.schematize_opp')
+    def test_transform_opps_duplicates(self, m_schematize_opp):
+        m_schematize_opp.return_value = mock_opps.mock_schematized_solnum_constraint_error[0]
+        result = transform_opps(mock_opps.mock_schematized_solnum_constraint_error, self.out_path, skip_attachments=True)
+        self.assertEqual(len(result), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_solicitation_update.py
+++ b/tests/test_solicitation_update.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import sys
 import unittest
-from fbo_scraper.db.db_utils import session_scope, DataAccessLayer
+from fbo_scraper.db.db_utils import DataAccessLayer
 from fbo_scraper.db.connection import get_db_url
 
 
@@ -19,7 +19,7 @@ class SamUtilsTestCase(unittest.TestCase):
         self.dal.connect()
 
     def tearDown(self):
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             clear_data(session)
         close_all_sessions()
         self.dal.drop_test_postgres_db()
@@ -28,7 +28,7 @@ class SamUtilsTestCase(unittest.TestCase):
 
     def test_update_old_solicitations(self):
 
-        with session_scope(self.dal) as session:
+        with self.dal.Session.begin() as session:
             sam_utils.update_old_solicitations(session, age_cutoff=365, max_tests=5)
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Changes

- [Fixing the no data to insert error message](https://github.com/GSA/srt-fbo-scraper/commit/3ec3f6495bf0078737861dd95c36d52d2e238385)
- [Dropping duplicate solication numbers received from SAM](https://github.com/GSA/srt-fbo-scraper/commit/25bea0bd91157408e1963275e1d3b261108e5c22)
- [Broke out inserting data into separate function](https://github.com/GSA/srt-fbo-scraper/commit/da788a896db03d56b47c5e047266d6c1bf3511d7)
- [Utilizing the SqlAlchemy built in session.begin() for testing](https://github.com/GSA/srt-fbo-scraper/commit/ec621614e41266ecd514a3d1772f34e68e5307e8)