### PR TITLE
feat(logging): add standard format logging alongside JSON

### DIFF
--- a/src/fbo_scraper/json_log_formatter.py
+++ b/src/fbo_scraper/json_log_formatter.py
@@ -8,7 +8,6 @@ import re
 from pathlib import Path
 from fbo_scraper import log_path
 
-
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
@@ -18,19 +17,18 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
             log_record["timestamp"] = now
         if log_record.get("level"):
             log_record["level"] = log_record["level"].lower()
-            if log_record["level"] == "level 12":
-                log_record["level"] = "found it top"
+        if log_record["level"] == "level 12":
+            log_record["level"] = "found it top"
         else:
             log_record["level"] = record.levelname.lower()
-
-        # did we set the level numerically?
-        matches = re.match("level ([0-9]*)", log_record["level"])
-        if matches:
-            l_int = int(matches.group(1))
-            if (l_int >= 10) and (
-                l_int < 20
-            ):  # greater than DEBUG but less then INFO gets marked as debug for log searching
-                log_record["level"] = "debug"
+            # did we set the level numerically?
+            matches = re.match("level ([0-9]*)", log_record["level"])
+            if matches:
+                l_int = int(matches.group(1))
+                if (l_int >= 10) and (
+                    l_int < 20
+                ): # greater than DEBUG but less then INFO gets marked as debug for log searching
+                    log_record["level"] = "debug"
 
     def process_log_record(self, log_record):
         """
@@ -45,29 +43,35 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
             if key not in ["message", "level", "timestamp", "meta"]:
                 log_record["meta"][key] = log_record[key]
                 to_be_removed.append(key)
-
         if "timestamp" in log_record:
             t = parser.parse(log_record["timestamp"])
             log_record["timestamp"] = t.strftime("%Y-%m-%dT%H:%M:%SZ")
-
         for key in to_be_removed:
             del log_record[key]
-
         return log_record
-
 
 def configureLogger(logger, log_file_level=logging.INFO, stdout_level=11):
     # stdout_level defaults to 11 so we get everything even a tiny bit more critical than DEBUG in the cloud.gov logs
     logger.setLevel(stdout_level)
 
     # json output setup
-    logHandler = logging.StreamHandler(stdout)
-    formatter = CustomJsonFormatter(
+    json_handler = logging.StreamHandler(stdout)
+    json_formatter = CustomJsonFormatter(
         "%(timestamp)s %(level)s %(message)s %(filename)s %(lineno)s"
-    )  # jsonlogger.JsonFormatter()
-    logHandler.setFormatter(formatter)
-    logHandler.setLevel(stdout_level)
-    logger.addHandler(logHandler)
+    )
+    json_handler.setFormatter(json_formatter)
+    json_handler.setLevel(stdout_level)
+    logger.addHandler(json_handler)
+
+    # Add standard formatter output
+    standard_handler = logging.StreamHandler(stdout)
+    standard_formatter = logging.Formatter(
+        '%(asctime)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%dT%H:%M:%SZ'
+    )
+    standard_handler.setFormatter(standard_formatter)
+    standard_handler.setLevel(stdout_level)
+    logger.addHandler(standard_handler)
 
     # file handler
     fh = TimedRotatingFileHandler(
@@ -78,7 +82,6 @@ def configureLogger(logger, log_file_level=logging.INFO, stdout_level=11):
     )
     fh.setLevel(log_file_level)
     logger.addHandler(fh)
-
+    
     logger.info("set log levels to {} and {}".format(log_file_level, stdout_level))
-
     return logger

--- a/src/fbo_scraper/json_log_formatter.py
+++ b/src/fbo_scraper/json_log_formatter.py
@@ -11,31 +11,32 @@ from fbo_scraper import log_path
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        
+        # Add timestamp if not present
         if not log_record.get("timestamp"):
-            # this doesn't use record.created, so it is slightly off
             now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
             log_record["timestamp"] = now
-        if log_record.get("level"):
-            log_record["level"] = log_record["level"].lower()
-        if log_record["level"] == "level 12":
-            log_record["level"] = "found it top"
+        
+        # Safely handle level using .get() to avoid KeyError
+        level = log_record.get("level")
+        if level:
+            log_record["level"] = level.lower()
+            if level == "level 12":
+                log_record["level"] = "found it top"
         else:
             log_record["level"] = record.levelname.lower()
-            # did we set the level numerically?
-            matches = re.match("level ([0-9]*)", log_record["level"])
-            if matches:
-                l_int = int(matches.group(1))
-                if (l_int >= 10) and (
-                    l_int < 20
-                ): # greater than DEBUG but less then INFO gets marked as debug for log searching
-                    log_record["level"] = "debug"
+        
+        # Level number matching - moved outside the else block as per review
+        matches = re.match("level ([0-9]*)", log_record.get("level", ""))
+        if matches:
+            l_int = int(matches.group(1))
+            if (l_int >= 10) and (l_int < 20):
+                log_record["level"] = "debug"
 
     def process_log_record(self, log_record):
         """
         Use this to move everything besides message, level, and timestamp into
-        a 'meta' dict to be compatable with cloud.gov loggerator
-        :param log_record:
-        :return:
+        a 'meta' dict to be compatible with cloud.gov loggerator
         """
         log_record["meta"] = dict()
         to_be_removed = []
@@ -43,9 +44,11 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
             if key not in ["message", "level", "timestamp", "meta"]:
                 log_record["meta"][key] = log_record[key]
                 to_be_removed.append(key)
+
         if "timestamp" in log_record:
             t = parser.parse(log_record["timestamp"])
             log_record["timestamp"] = t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
         for key in to_be_removed:
             del log_record[key]
         return log_record
@@ -54,7 +57,7 @@ def configureLogger(logger, log_file_level=logging.INFO, stdout_level=11):
     # stdout_level defaults to 11 so we get everything even a tiny bit more critical than DEBUG in the cloud.gov logs
     logger.setLevel(stdout_level)
 
-    # json output setup
+    # Add JSON handler
     json_handler = logging.StreamHandler(stdout)
     json_formatter = CustomJsonFormatter(
         "%(timestamp)s %(level)s %(message)s %(filename)s %(lineno)s"
@@ -63,7 +66,7 @@ def configureLogger(logger, log_file_level=logging.INFO, stdout_level=11):
     json_handler.setLevel(stdout_level)
     logger.addHandler(json_handler)
 
-    # Add standard formatter output
+    # Standard formatter output
     standard_handler = logging.StreamHandler(stdout)
     standard_formatter = logging.Formatter(
         '%(asctime)s - %(levelname)s - %(message)s',
@@ -73,7 +76,7 @@ def configureLogger(logger, log_file_level=logging.INFO, stdout_level=11):
     standard_handler.setLevel(stdout_level)
     logger.addHandler(standard_handler)
 
-    # file handler
+    # File handler
     fh = TimedRotatingFileHandler(
         Path(log_path, "smartie-logger.log"), when="midnight", backupCount=14
     )
@@ -83,5 +86,5 @@ def configureLogger(logger, log_file_level=logging.INFO, stdout_level=11):
     fh.setLevel(log_file_level)
     logger.addHandler(fh)
     
-    logger.info("set log levels to {} and {}".format(log_file_level, stdout_level))
+    logger.info("Set log levels to {} and {}".format(log_file_level, stdout_level))
     return logger


### PR DESCRIPTION
- Add standard formatter to complement existing JSON format
- Keep both formats
- Format: '{timestamp} - {level} - {message}'
- Goal: debug log visibility in cloud.gov

Adding a standard, human-readable log handler alongside the existing format means you can cross-check that logs are being sent properly in both styles. This makes it easier to pinpoint any issues related to formatting, configuration, or how cloud.gov processes logs