### PR TITLE
Separation Report Utility Tool 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fbo-scraper
-version = 2.1.0
+version = 2.2.0
 author = Adam Buckingham
 author_email = adam.buckingham@gsa.gov
 description = This project gathers Information Technology (IT) solicitations that are posted by the US Federal Government on beta.sam.gov.
@@ -52,6 +52,7 @@ dev =
     reportlab
     ruff
     selenium
+    tqdm
 
 [options.package_data]
 mypkg =
@@ -70,4 +71,5 @@ exclude =
 console_scripts =
     fbo_scraper = fbo_scraper.main:actual_main
     ebuy_parser = fbo_scraper.util.ebuy_csv:main
+    separation_report = fbo_scraper.util.separation_report:main
 

--- a/src/fbo_scraper/json_log_formatter.py
+++ b/src/fbo_scraper/json_log_formatter.py
@@ -5,6 +5,10 @@ from dateutil import parser
 from pathlib import Path
 from logging.handlers import TimedRotatingFileHandler
 
+# Define log directory relative to the project root
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+LOG_DIR = PROJECT_ROOT / "logs"
+
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super().add_fields(log_record, record, message_dict)
@@ -39,17 +43,40 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
 
 def configure_logger(logger, options, stdout_level=logging.INFO):
     """Configure logger with either JSON or standard formatting"""
-    logger.handlers = []
-    
+    import sys
+    import os    
     # Cleaner options check using DotDict
+
+    handlers = []
+
     if options.client.json_logging:
         formatter = CustomJsonFormatter()
     else:
         formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
     
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
     handler.setLevel(stdout_level)
-    logger.addHandler(handler)
+    handlers.append(handler)
+
+    # Create logs directory if it doesn't exist
+    os.makedirs(LOG_DIR, exist_ok=True)
+
+    # File handler
+    log_file_path = LOG_DIR / "smartie-logger.log"
+    fh = TimedRotatingFileHandler(
+        log_file_path,
+        when="midnight",
+        backupCount=14
+    )
+    fh.setFormatter(formatter)
+    fh.setLevel(stdout_level)
+    handlers.append(fh)
+
+    logging.basicConfig(handlers=handlers, level=stdout_level, force=True)
     
+    logger.info(f"Log file location: {log_file_path}")
+
     return logger
+
+__all__ = ['configure_logger', 'CustomJsonFormatter']

--- a/src/fbo_scraper/util/separation_report.py
+++ b/src/fbo_scraper/util/separation_report.py
@@ -133,6 +133,7 @@ def process_separation_report(options):
         if options.government_file:
             process_government(options.government_file, session)
 
+    logger.info("Separation Report Processing Complete")
 
     if db_child:
         db_child.close()

--- a/src/fbo_scraper/util/separation_report.py
+++ b/src/fbo_scraper/util/separation_report.py
@@ -80,7 +80,12 @@ def separation_parser():
 
     return parser
 
-def process_not_government(file_path: str, session):
+def process_not_government(file_path: Path, session):
+    
+    if not file_path.exists():
+        logger.error(f"File {file_path} does not exist")
+        return
+    
     employees_listed = parse_csv(file_path)
 
     try:
@@ -99,7 +104,11 @@ def process_not_government(file_path: str, session):
         raise e
     
 
-def process_government(file_path: str, session):
+def process_government(file_path: Path, session):
+    if not file_path.exists():
+        logger.error(f"File {file_path} does not exist")
+        return
+
     employees_listed = parse_csv(file_path)
 
     try:
@@ -128,10 +137,12 @@ def process_separation_report(options):
 
     with dal.Session.begin() as session:
         if options.not_government_file:
-            process_not_government(options.not_government_file, session)
+            with session.begin_nested():
+                process_not_government(Path(options.not_government_file), session)
         
         if options.government_file:
-            process_government(options.government_file, session)
+            with session.begin_nested():
+                process_government(Path(options.government_file), session)
 
     logger.info("Separation Report Processing Complete")
 

--- a/src/fbo_scraper/util/separation_report.py
+++ b/src/fbo_scraper/util/separation_report.py
@@ -1,0 +1,160 @@
+""" 
+Command line tool to generate users that need to be removed from out User db.
+"""
+
+
+import logging
+from pathlib import Path
+import sys, traceback
+from datetime import datetime
+from typing import Any
+from addict import Addict
+from fbo_scraper.options import pre_main
+from .ebuy_csv import db_forwarding, parse_csv
+from tqdm import tqdm
+from argparse import BooleanOptionalAction
+
+import functools
+from copy import deepcopy
+from fbo_scraper.json_log_formatter import configure_logger
+from fbo_scraper.options.parser import make_parser
+from fbo_scraper.db.connection import DataAccessLayer, get_db_url, DALException
+
+from fbo_scraper.db.db import Users
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BASE_DIR = sys.prefix
+
+BASE_PKG_DIR = Path(__file__).parent.parent.parent.parent
+connection_params = {'connect_timeout': 30}
+
+logger = logging.getLogger()
+
+def setup_logging(options):
+    """Initialize logging configuration"""
+    global logger
+    logger = configure_logger(
+        logger,
+        options,
+        stdout_level=logging.DEBUG
+    )
+
+    return logger
+
+def setup_db():
+    conn_string = get_db_url()
+    dal = DataAccessLayer(conn_string, connection_params)
+    dal.connect()
+    return dal
+
+def separation_parser():
+
+    parser = make_parser()
+
+    parser.add_argument(
+        "-n",
+        "--not-government",
+        dest="not_government_file",
+        required=False,
+        help="Full Path to Not Government employees Separation Report",
+    )
+
+    parser.add_argument(
+        "-g",
+        "--government",
+        dest="government_file",
+        required=False,
+        help="Full Path to Government employees Separation Report",
+    )
+
+    parser.add_argument(
+        "-e",
+        "--environment",
+        dest="environment",
+        required=False,
+        default="local",
+        help="Define the cloud.gov environment for data insertion",
+    )
+
+    return parser
+
+def process_not_government(file_path: str, session):
+    employees_listed = parse_csv(file_path)
+
+    try:
+        logger.info("Progress on Not Government Separation Report")
+        for employee in tqdm(employees_listed):
+            user = session.query(Users).filter(
+                Users.firstName == employee.get('First name'),
+                Users.lastName == employee.get('Last name')).first()
+            if user:
+                logger.info(f"User {user.firstName} {user.lastName} is marked as Rejected")
+                user.isRejected = True
+                user.isAccepted = False
+
+    except Exception as e:
+        logger.error("Error with Not Government Separation Report User Query")
+        raise e
+    
+
+def process_government(file_path: str, session):
+    employees_listed = parse_csv(file_path)
+
+    try:
+        logger.info("Progress on Government Separation Report")
+        for employee in tqdm(employees_listed):
+            user = session.query(Users).filter(
+                Users.email == employee.get('email')).first()
+            if user:
+                logger.info(f"User {user.firstName} {user.lastName} is marked as Rejected")
+                user.isRejected = True
+                user.isAccepted = False
+
+    except Exception as e:
+        logger.error("Error with Not Government Separation Report User Query")
+        raise e
+
+
+def process_separation_report(options):
+
+    logger.info("Starting Separation Report Processing")
+
+    db_child = db_forwarding(options.environment)
+
+    logger.info("Connecting to Database...")
+    dal = setup_db()
+
+    with dal.Session.begin() as session:
+        if options.not_government_file:
+            process_not_government(options.not_government_file, session)
+        
+        if options.government_file:
+            process_government(options.government_file, session)
+
+
+    if db_child:
+        db_child.close()
+
+
+def main():
+    options = pre_main(
+        app_name="Separation Report Tool",
+        app_version="0.0.1",
+        _make_parser=separation_parser,
+    )
+
+    setup_logging(options)
+
+    try:
+        process_separation_report(options)
+    except KeyboardInterrupt:
+        logger.exception("Keyboard Interrupt")
+    except Exception as e:
+        logger.exception("Error processing Separation Reports")
+        traceback.print_exc(file=sys.stdout)
+
+
+
+    


### PR DESCRIPTION
# Changes
- Added a utility tool that runs through the separation reports sent out by the CISO, and checks if those users are in the Users database. 
- Also adjusted the logging to include back in the TimeRotatingFileHandler. Important because just incase cloud.gov doesn't catch the logs we can still verify.
-  Adjusted the configuration for the logger so it'll now print out to the stdout. 