### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'dev'
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     name: Build and Push Docker Image


### PR DESCRIPTION
## Summary
- Add an explicit `permissions` block to `.github/workflows/deploy.dev.yml`.
- Set `contents: read` as the minimal `GITHUB_TOKEN` scope.

## Why
The workflow currently relies on implicit token defaults. Explicit least-privilege scoping reduces unnecessary token access without changing deploy behavior.